### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ If you're building a Koa app, you can use these generated types with the `implem
 import Koa from 'koa';
 import Router from 'koa-router';
 
-import { implementSchema } from 'one-schema';
+import { implementSchema } from '@lifeomic/one-schema';
 
-import { APISchema } from './generated-api.ts';
+import { Schema } from './generated-api.ts';
 
 const router = new Router();
 
-implementSchema(APISchema, {
+implementSchema(Schema, {
   on: router,
   parse: (ctx, endpoint, schema, data) => {
     // validate that `data` matches `schema`, using whatever


### PR DESCRIPTION
Here are two little things I noticed in the readme that ended up not being quite right.

Also, a suggestion. It might be that I am not fully understanding, but on some endpoints it seems that it may be pretty typical to have no need for a Request body. Yet when I tried to generate the schemas without one I was getting an error that it was required. I got around it by adding an empty set

```
    Request:
      type: 'object'
```

Could we make the Request optional? or default it to ☝️. 