### PR TITLE
feat: add support for undefined Request schema

### DIFF
--- a/src/generate-api-types.test.ts
+++ b/src/generate-api-types.test.ts
@@ -25,6 +25,11 @@ describe('generate', () => {
                 },
               },
             },
+            'DELETE /posts/:id': {
+              Name: 'deletePost',
+              Response: {},
+              // Test no Request field
+            },
             'PUT /posts/:id': {
               Name: 'putPost',
               Request: {
@@ -60,6 +65,13 @@ export type Endpoints = {
       output?: string;
     };
   };
+  "DELETE /posts/:id": {
+    Request: unknown;
+    PathParams: {
+      id: string;
+    };
+    Response: unknown;
+  };
   "PUT /posts/:id": {
     Request: {
       message: string;
@@ -90,6 +102,7 @@ export const Schema: OneSchema<Endpoints> = {
         properties: { output: { type: "string" } },
       },
     },
+    "DELETE /posts/:id": { Name: "deletePost", Response: {} },
     "PUT /posts/:id": {
       Name: "putPost",
       Request: {

--- a/src/generate-endpoints.ts
+++ b/src/generate-endpoints.ts
@@ -23,7 +23,7 @@ export const generateEndpointTypes = async ({
           additionalProperties: false,
           required: ['Request', 'PathParams', 'Response'],
           properties: {
-            Request,
+            Request: Request ?? {},
             PathParams: {
               type: 'object',
               additionalProperties: false,

--- a/src/koa.ts
+++ b/src/koa.ts
@@ -80,15 +80,18 @@ export const implementSchema = <State, Context, Schema extends OneSchema<any>>(
     /** A shared route handler. */
     const handler: Router.IMiddleware<State, Context> = async (ctx, next) => {
       // 1. Validate the input data.
-      ctx.request.body = parse(
-        ctx,
-        endpoint,
-        { ...Endpoints[endpoint].Request, definitions: Resources },
-        // 1a. For GET and DELETE, use the query parameters. Otherwise, use the body.
-        ['GET', 'DELETE'].includes(method)
-          ? ctx.request.query
-          : ctx.request.body,
-      );
+      const requestSchema = Endpoints[endpoint].Request;
+      if (requestSchema) {
+        ctx.request.body = parse(
+          ctx,
+          endpoint,
+          { ...requestSchema, definitions: Resources },
+          // 1a. For GET and DELETE, use the query parameters. Otherwise, use the body.
+          ['GET', 'DELETE'].includes(method)
+            ? ctx.request.query
+            : ctx.request.body,
+        );
+      }
 
       // 2. Run the provided route handler.
       const response = await routeHandler(ctx);

--- a/src/meta-schema.test.ts
+++ b/src/meta-schema.test.ts
@@ -173,6 +173,19 @@ describe('loadSchemaFromFile', () => {
 });
 
 describe('validateSchema', () => {
+  test('allows undefined Request schemas', () => {
+    expect(() =>
+      validateSchema({
+        Endpoints: {
+          'POST /posts': {
+            Name: 'something',
+            Response: {},
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   test('checks for object types in Request schemas', () => {
     expect(() =>
       validateSchema({

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -69,6 +69,12 @@ const TEST_SPEC: OneSchemaDefinition = withAssumptions({
         $ref: '#/definitions/Post',
       },
     },
+    'DELETE /posts/:id': {
+      Name: 'deletePost',
+      Response: {
+        $ref: '#/definitions/Post',
+      },
+    },
   },
 });
 
@@ -177,6 +183,31 @@ describe('toOpenAPISpec', () => {
           },
         },
         '/posts/{id}': {
+          delete: {
+            operationId: 'deletePost',
+            parameters: [
+              {
+                in: 'path',
+                name: 'id',
+                required: true,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: '#/components/schemas/Post',
+                    },
+                  },
+                },
+                description: 'TODO',
+              },
+            },
+          },
           get: {
             operationId: 'getPostById',
             parameters: [

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -77,29 +77,32 @@ export const toOpenAPISpec = (
       required: true,
     }));
 
-    if (['GET', 'DELETE'].includes(method)) {
-      // Add the query parameters for GET/DELETE methods
-      for (const [name, schema] of Object.entries(Request.properties ?? {}))
-        parameters.push({
-          in: 'query',
-          name,
-          description: schema.description,
-          schema: { type: 'string' },
-          required:
-            Array.isArray(Request.required) && Request.required.includes(name),
-        });
-    } else {
-      // Add the body spec parameters for non-GET/DELETE methods
-      operation.requestBody = {
-        content: {
-          'application/json': {
-            // @ts-expect-error TS detects a mismatch between the JSONSchema types
-            // between openapi-types and json-schema. Ignore and assume everything
-            // is cool.
-            schema: Request,
+    if (Request) {
+      if (['GET', 'DELETE'].includes(method)) {
+        // Add the query parameters for GET/DELETE methods
+        for (const [name, schema] of Object.entries(Request.properties ?? {}))
+          parameters.push({
+            in: 'query',
+            name,
+            description: schema.description,
+            schema: { type: 'string' },
+            required:
+              Array.isArray(Request.required) &&
+              Request.required.includes(name),
+          });
+      } else {
+        // Add the body spec parameters for non-GET/DELETE methods
+        operation.requestBody = {
+          content: {
+            'application/json': {
+              // @ts-expect-error TS detects a mismatch between the JSONSchema types
+              // between openapi-types and json-schema. Ignore and assume everything
+              // is cool.
+              schema: Request,
+            },
           },
-        },
-      };
+        };
+      }
     }
 
     if (parameters.length) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { JSONSchema4 } from 'json-schema';
 
 export type EndpointDefinition = {
   Name: string;
-  Request: JSONSchema4;
+  Request?: JSONSchema4;
   Response: JSONSchema4;
 };
 
@@ -28,7 +28,7 @@ export type OneSchema<Endpoints extends GeneratedEndpointsType> =
   OneSchemaDefinition & {
     Endpoints: {
       [K in keyof Endpoints]: {
-        Request: JSONSchema4;
+        Request?: JSONSchema4;
         Response: JSONSchema4;
       };
     };


### PR DESCRIPTION
## Motivation
Allowing the `Request` schema to be undefined for any endpoint. If it is not defined, the generation will generate `unknown` for its type.