### PR TITLE
feat: store input in query parameter for GET/DELETE

### DIFF
--- a/src/integration.koa.test.ts
+++ b/src/integration.koa.test.ts
@@ -150,7 +150,7 @@ test('GET method', async () => {
     {
       implementation: {
         'GET /posts': (ctx) => {
-          return ctx.request.body;
+          return ctx.request.query;
         },
       },
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "inlineSources": false,
     "inlineSourceMap": false,
     "esModuleInterop": false,
-    "declaration": true
+    "declaration": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
**Note**: This PR depends on #12.

## Motivation
Currently, the `koa` helper in this package uses `ctx.request.body` to store the query parameters for GET + DELETE requests. This was a weird pattern, and didn't fit with the pattern used by the rest of the typing.

This puts query parameter behavior into the same pattern as the rest of the typing: "type the existing Koa parameters". Query parameters can now be correctly accessed using `ctx.request.query`.

This is _technically_ a breaking change, since the query parameters will not be accessible in `ctx.request.body` anymore.