### PR TITLE
[Proposal] Default to using 'all' assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ Endpoints:
         $ref: '#/definitions/Post'
 ```
 
-### Schema Assumptions
-
-`one-schema` provides a set of JSONSchema assumptions to help simplify Request/Response JSONSchema entries in commonly desired ways.
-
-These assumptions are described by the `SchemaAssumptions` type in [`src/meta-schema.ts`](src/meta-schema.ts) and can be individually or wholly disabled in the Node API and at the command line via the `--asssumptions` flag.
-
 ### Axios Client Generation
 
 Use the `generate-axios-client` command to generate a nicely typed Axios-based client from the schema.
@@ -59,7 +53,6 @@ Use the `generate-axios-client` command to generate a nicely typed Axios-based c
 one-schema generate-axios-client \
   --schema schema.yml \
   --output generated-client.ts \
-  --assumptions all \
   --format
 ```
 
@@ -171,7 +164,6 @@ Use the `generate-api-types` command to generate helpful types to use for server
 one-schema generate-api-types \
   --schema schema.yml \
   --output generated-api.ts \
-  --assumptions all \
   --format
 ```
 
@@ -265,7 +257,6 @@ Use the `generate-open-api-spec` command to generate an OpenAPI spec from a simp
 one-schema generate-open-api-spec \
   --schema schema.yml \
   --output openapi-schema.json \
-  --assumptions all \
   --apiVersion "1.0.0" \
   --apiTitle "Simple API" \
   --format
@@ -362,4 +353,62 @@ The output (in `generated-openapi-schema.json`):
     }
   }
 }
+```
+
+### Schema Assumptions
+
+`one-schema` provides a set of JSONSchema assumptions to help simplify Request/Response JSONSchema entries in commonly desired ways.
+
+These assumptions are described by the `SchemaAssumptions` type in [`src/meta-schema.ts`](src/meta-schema.ts) and can be individually or wholly disabled in the Node API and at the command line via the `--asssumptions` flag.
+
+By default, all assumptions are applied.
+
+#### noAdditionalPropertiesOnObjects
+
+Enabling this assumption will automatically add `additionalProperties: false` to all `object` JSONSchemas. Example:
+
+```yaml
+PUT /posts/:id:
+  Request:
+    type: object
+    properties:
+      message:
+        type: string
+
+# Automatically interpreted as:
+PUT /posts/:id:
+  Request:
+    type: object
+    additionalProperties: false
+    properties:
+      message:
+        type: string
+```
+
+#### objectPropertiesRequiredByDefault
+
+Enabling this assumption will automatically add mark every object property as "required", unless that property's schema has `optional: true` defined. Example:
+
+```yaml
+PUT /posts/:id:
+  Request:
+    type: object
+    properties:
+      message:
+        type: string
+      title:
+        type: string
+        optional: true
+
+# Automatically interpreted as:
+PUT /posts/:id:
+  Request:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        type: string
+      title:
+        type: string
 ```

--- a/src/bin/__snapshots__/cli.test.ts.snap
+++ b/src/bin/__snapshots__/cli.test.ts.snap
@@ -51,7 +51,7 @@ Options:
   --assumptions  Which JSONSchema assumptions to apply. Must be either 'all',
                  'none', or a comma-separated list containing one or more of:
                  noAdditionalPropertiesOnObjects,
-                 objectPropertiesRequiredByDefault    [string] [default: \\"none\\"]
+                 objectPropertiesRequiredByDefault     [string] [default: \\"all\\"]
 
 Missing required arguments: schema, output"
 `;
@@ -71,7 +71,7 @@ Options:
   --assumptions  Which JSONSchema assumptions to apply. Must be either 'all',
                  'none', or a comma-separated list containing one or more of:
                  noAdditionalPropertiesOnObjects,
-                 objectPropertiesRequiredByDefault    [string] [default: \\"none\\"]
+                 objectPropertiesRequiredByDefault     [string] [default: \\"all\\"]
   --className    The name of the generated client class.
                                                     [string] [default: \\"Client\\"]
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -99,7 +99,7 @@ const getCommonOptions = (argv: yargs.Argv) =>
       description:
         "Which JSONSchema assumptions to apply. Must be either 'all', 'none', or a comma-separated list containing one or more of: " +
         VALID_ASSUMPTION_KEYS.join(', '),
-      default: 'none',
+      default: 'all',
     });
 
 const program = yargs(process.argv.slice(2))


### PR DESCRIPTION
## Motivation
This package provides a couple nice "assumptions" that you can specify to simplify schemas. Currently, there are two possible assumptions --  I added more explicit documentation about them to the README.

I'd like to propose enabling these both by default. Why:
- TypeScript follows the pattern of "required by default". Enabling the `objectPropertiesRequiredByDefault` assumption will prevent footguns from developers forgetting to update the `required` array.
- If `additionalProperties: false` is not specified on object types, the generated types can become pretty wacky. Enabling `noAdditionalPropertiesOnObjects` will result in cleaner generation.