### PR TITLE
[Proposal] Add basic tool for generating a publishable artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,35 @@ const server = new Koa()
   .listen();
 ```
 
+### Distributing Schemas
+
+Use the `generate-publishable-schema` command in concert with the `Meta.PackageJSON` entry to generate a ready-to-publish NPM artifact containing the schema.
+
+```yaml
+# schema.yml
+Meta:
+  PackageJSON:
+    name: desired-package-name
+    description: A description of the package
+    # ... any other desired package.json values
+# ...
+```
+
+```bash
+one-schema generate-publishable \
+  --schema schema.yml \
+  --output output-directory
+```
+
+The `output-directory` will have this file structure:
+
+```
+output-directory/
+  package.json
+  schema.json
+  schema.yaml
+```
+
 ### OpenAPI Spec generation
 
 Use the `generate-open-api-spec` command to generate an OpenAPI spec from a simple schema, which may be useful for interfacing with common OpenAPI tooling.

--- a/src/bin/__snapshots__/cli.test.ts.snap
+++ b/src/bin/__snapshots__/cli.test.ts.snap
@@ -4,12 +4,13 @@ exports[`input validation snapshots bogus command name 1`] = `
 "cli.ts <command>
 
 Commands:
-  cli.ts generate-axios-client   Generates an Axios client using the specified
-                                 schema and options.
-  cli.ts generate-api-types      Generates API types using the specified schema
-                                 and options.
-  cli.ts generate-open-api-spec  Generates an OpenAPI v3.1.0 spec using the
-                                 specified schema and options.
+  cli.ts generate-axios-client        Generates an Axios client using the
+                                      specified schema and options.
+  cli.ts generate-api-types           Generates API types using the specified
+                                      schema and options.
+  cli.ts generate-open-api-spec       Generates an OpenAPI v3.1.0 spec using the
+                                      specified schema and options.
+  cli.ts generate-publishable-schema  Generates a publishable schema artifact.
 
 Options:
   --help     Show help                                                 [boolean]
@@ -22,12 +23,13 @@ exports[`input validation snapshots empty input 1`] = `
 "cli.ts <command>
 
 Commands:
-  cli.ts generate-axios-client   Generates an Axios client using the specified
-                                 schema and options.
-  cli.ts generate-api-types      Generates API types using the specified schema
-                                 and options.
-  cli.ts generate-open-api-spec  Generates an OpenAPI v3.1.0 spec using the
-                                 specified schema and options.
+  cli.ts generate-axios-client        Generates an Axios client using the
+                                      specified schema and options.
+  cli.ts generate-api-types           Generates API types using the specified
+                                      schema and options.
+  cli.ts generate-open-api-spec       Generates an OpenAPI v3.1.0 spec using the
+                                      specified schema and options.
+  cli.ts generate-publishable-schema  Generates a publishable schema artifact.
 
 Options:
   --help     Show help                                                 [boolean]

--- a/src/generate-publishable-schema.test.ts
+++ b/src/generate-publishable-schema.test.ts
@@ -1,0 +1,96 @@
+import { generatePublishableSchema } from './generate-publishable-schema';
+
+test('skips generating a package.json if there is no PackageJSON entry', () => {
+  const result = generatePublishableSchema({
+    spec: {
+      Endpoints: {
+        'GET /posts': {
+          Name: 'listPosts',
+          Response: {},
+          Request: {},
+        },
+      },
+    },
+  });
+
+  expect(result.files['package.json']).toBeUndefined();
+});
+
+test('generates the correct files when there is a PackageJSON entry', () => {
+  const result = generatePublishableSchema({
+    spec: {
+      Meta: {
+        PackageJSON: {
+          name: '@lifeomic/test-service-schema',
+          description: 'The OneSchema for a test-service',
+          testObject: {
+            some: 'value',
+          },
+        },
+      },
+      Endpoints: {
+        'GET /posts': {
+          Name: 'listPosts',
+          Response: {},
+          Request: {},
+        },
+      },
+    },
+  });
+
+  expect(Object.keys(result.files)).toStrictEqual([
+    'schema.json',
+    'schema.yaml',
+    'package.json',
+  ]);
+
+  expect(result.files['schema.json']).toStrictEqual(
+    `
+{
+  "Meta": {
+    "PackageJSON": {
+      "name": "@lifeomic/test-service-schema",
+      "description": "The OneSchema for a test-service",
+      "testObject": {
+        "some": "value"
+      }
+    }
+  },
+  "Endpoints": {
+    "GET /posts": {
+      "Name": "listPosts",
+      "Response": {},
+      "Request": {}
+    }
+  }
+}`.trim(),
+  );
+
+  expect(result.files['schema.yaml']).toStrictEqual(
+    `
+Meta:
+  PackageJSON:
+    name: '@lifeomic/test-service-schema'
+    description: The OneSchema for a test-service
+    testObject:
+      some: value
+Endpoints:
+  GET /posts:
+    Name: listPosts
+    Response: {}
+    Request: {}
+`.trimStart(),
+  );
+
+  expect(result.files['package.json']).toStrictEqual(
+    `
+{
+  "name": "@lifeomic/test-service-schema",
+  "description": "The OneSchema for a test-service",
+  "testObject": {
+    "some": "value"
+  }
+}
+`.trim(),
+  );
+});

--- a/src/generate-publishable-schema.ts
+++ b/src/generate-publishable-schema.ts
@@ -1,0 +1,28 @@
+import * as jsyaml from 'js-yaml';
+import { OneSchemaDefinition } from '.';
+
+export type GeneratePublishableSchemaInput = {
+  spec: OneSchemaDefinition;
+};
+
+export type GeneratePublishableSchemaOutput = {
+  /**
+   * A map of filename -> file content to generate.
+   */
+  files: Record<string, string>;
+};
+
+export const generatePublishableSchema = ({
+  spec,
+}: GeneratePublishableSchemaInput): GeneratePublishableSchemaOutput => {
+  const files: Record<string, string> = {
+    'schema.json': JSON.stringify(spec, null, 2),
+    'schema.yaml': jsyaml.dump(spec),
+  };
+
+  if (spec.Meta?.PackageJSON) {
+    files['package.json'] = JSON.stringify(spec.Meta.PackageJSON, null, 2);
+  }
+
+  return { files };
+};

--- a/src/meta-schema.ts
+++ b/src/meta-schema.ts
@@ -14,10 +14,22 @@ export const getPathParams = (name: string) =>
     .map((part) => part.replace(':', ''));
 
 const ONE_SCHEMA_META_SCHEMA: JSONSchema4 = {
+  definitions: {
+    MetaConfig: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        PackageJSON: { type: 'object' },
+      },
+    },
+  },
   type: 'object',
   additionalProperties: false,
   required: ['Endpoints'],
   properties: {
+    Meta: {
+      $ref: '#/definitions/MetaConfig',
+    },
     Resources: {
       type: 'object',
       patternProperties: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,13 @@ export type EndpointDefinition = {
   Response: JSONSchema4;
 };
 
+export type OneSchemaMetaDefinition = {
+  PackageJSON?: Record<string, unknown>;
+};
+
 export type OneSchemaDefinition = {
+  Meta?: OneSchemaMetaDefinition;
+
   Resources?: {
     [key: string]: JSONSchema4;
   };


### PR DESCRIPTION
## Motivation
Curious what people think about this.

A key value-prop of this package is being able to easily deliver schema correctness across many projects.

In order to do that, we need some way to distribute schemas (or clients).

For now, I'd like to propose this:
- Add a new CLI command + Node API: `generate-publishable-schema`.
  - This command generates a ready-to-publish NPM package folder that contains JSON and YAML versions of the schema.
- The implementing `xxxx-service` repo would regularly publish this schema artifact to NPM, through any mechanism they like, e.g.:
  - semantic-release
  - version bumping
- Other projects that want to consume the service would: 
  - add a dependency on the published schema package
  - `yarn add -D @lifeomic/one-schema`
  - `yarn one-schema generate-axios-client ./node_modules/path/to/published/schema`
  - Use the nicely generated axios client

In the future, I think it'd be nice to simplify the flow down to:
- Implementing service publishes well-typed client directly in the npm package.
- Consuming projects `yarn add` the nice client package, and start using it immediately (no generation required).

But, this is a quicker solution for right now. Hopefully some time in the next week or so, I can get "publishing clients" working.