### PR TITLE
feat: add a tool for publishing nice client packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 coverage
 .vscode
 dist/
-src/test-generated.ts
+src/test-generated.js
+src/test-generated.d.ts

--- a/README.md
+++ b/README.md
@@ -56,78 +56,16 @@ one-schema generate-axios-client \
   --format
 ```
 
-The output (in `generated-client.ts`):
+This command will output two files:
 
-```typescript
-/* eslint-disable */
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+- `generated-client.js`
+- `generated-client.d.ts`
 
-export type Endpoints = {
-  'POST /posts': {
-    Request: {
-      message: string;
-    };
-    PathParams: {};
-    Response: Post;
-  };
-  'GET /posts': {
-    Request: {
-      filter: string;
-    };
-    PathParams: {};
-    Response: Post[];
-  };
-};
-
-export type Post = {
-  /**
-   * The post's unique identifier.
-   */
-  id: string;
-  /**
-   * The post message.
-   */
-  message: string;
-};
-
-// ... various helpers ...
-
-export class Client {
-  constructor(private readonly client: AxiosInstance) {}
-
-  createPost(
-    data: Endpoints['POST /posts']['Request'] &
-      Endpoints['POST /posts']['PathParams'],
-    config?: AxiosRequestConfig,
-  ): Promise<AxiosResponse<Endpoints['POST /posts']['Response']>> {
-    return this.client.request({
-      ...config,
-      method: 'POST',
-      data: removePathParams('/posts', data),
-      url: substituteParams('/posts', data),
-    });
-  }
-
-  listPosts(
-    params: Endpoints['GET /posts']['Request'] &
-      Endpoints['GET /posts']['PathParams'],
-    config?: AxiosRequestConfig,
-  ): Promise<AxiosResponse<Endpoints['GET /posts']['Response']>> {
-    return this.client.request({
-      ...config,
-      method: 'GET',
-      params: removePathParams('/posts', params),
-      url: substituteParams('/posts', params),
-    });
-  }
-}
-```
-
-Usage:
+How to use the generated client:
 
 ```typescript
 import axios from 'axios';
-import { Client } from './generated-client.ts';
+import { Client } from './generated-client';
 
 // Provide any AxiosInstance, customized to your needs.
 const client = new Client(axios.create({ baseURL: 'https://my.api.com/' }));
@@ -215,7 +153,7 @@ import Router from 'koa-router';
 
 import { implementSchema } from '@lifeomic/one-schema';
 
-import { Schema } from './generated-api.ts';
+import { Schema } from './generated-api';
 
 const router = new Router();
 
@@ -264,7 +202,7 @@ Meta:
 ```
 
 ```bash
-one-schema generate-publishable \
+one-schema generate-publishable-schema \
   --schema schema.yml \
   --output output-directory
 ```
@@ -276,6 +214,48 @@ output-directory/
   package.json
   schema.json
   schema.yaml
+```
+
+### Distributing Clients
+
+Use the `generate-publishable-client` command in concert with the `Meta.PackageJSON` entry to generate a ready-to-publish NPM artifact containing a ready-to-use client.
+
+```yaml
+# schema.yml
+Meta:
+  PackageJSON:
+    name: desired-package-name
+    description: A description of the package
+    # ... any other desired package.json values
+# ...
+```
+
+```bash
+one-schema generate-publishable-client \
+  --schema schema.yml \
+  --output output-directory
+```
+
+The `output-directory` will have this file structure:
+
+```
+output-directory/
+  package.json
+  schema.json
+  schema.yaml
+  index.js
+  index.d.ts
+```
+
+The generated client code is identical to the output of `generate-axios-client`:
+
+```typescript
+import axios from 'axios';
+import { Client } from './output-directory';
+
+const client = new Client(axios.create(...))
+
+// use the client
 ```
 
 ### OpenAPI Spec generation

--- a/src/bin/__snapshots__/cli.test.ts.snap
+++ b/src/bin/__snapshots__/cli.test.ts.snap
@@ -11,6 +11,7 @@ Commands:
   cli.ts generate-open-api-spec       Generates an OpenAPI v3.1.0 spec using the
                                       specified schema and options.
   cli.ts generate-publishable-schema  Generates a publishable schema artifact.
+  cli.ts generate-publishable-client  Generates a publishable client artifact.
 
 Options:
   --help     Show help                                                 [boolean]
@@ -30,6 +31,7 @@ Commands:
   cli.ts generate-open-api-spec       Generates an OpenAPI v3.1.0 spec using the
                                       specified schema and options.
   cli.ts generate-publishable-schema  Generates a publishable schema artifact.
+  cli.ts generate-publishable-client  Generates a publishable client artifact.
 
 Options:
   --help     Show help                                                 [boolean]

--- a/src/generate-publishable-client.test.ts
+++ b/src/generate-publishable-client.test.ts
@@ -1,0 +1,85 @@
+import { generateAxiosClient } from './generate-axios-client';
+import { generatePublishableClient } from './generate-publishable-client';
+import { generatePublishableSchema } from './generate-publishable-schema';
+
+test('skips generating a package.json if there is no PackageJSON entry', async () => {
+  const result = await generatePublishableClient({
+    outputClass: 'Client',
+    spec: {
+      Endpoints: {
+        'GET /posts': {
+          Name: 'listPosts',
+          Response: {},
+          Request: {},
+        },
+      },
+    },
+  });
+
+  expect(result.files['package.json']).toBeUndefined();
+});
+
+test('generates the correct files when there is a PackageJSON entry', async () => {
+  const spec = {
+    Meta: {
+      PackageJSON: {
+        name: '@lifeomic/test-service-schema',
+        description: 'The OneSchema for a test-service',
+        testObject: {
+          some: 'value',
+        },
+      },
+    },
+    Endpoints: {
+      'GET /posts': {
+        Name: 'listPosts',
+        Response: {},
+        Request: {},
+      },
+    },
+  };
+  const result = await generatePublishableClient({
+    outputClass: 'Client',
+    spec,
+  });
+
+  expect(Object.keys(result.files)).toStrictEqual([
+    'schema.json',
+    'schema.yaml',
+    'package.json',
+    'index.js',
+    'index.d.ts',
+  ]);
+
+  const schemaArtifact = generatePublishableSchema({ spec });
+
+  expect(result.files['schema.json']).toStrictEqual(
+    schemaArtifact.files['schema.json'],
+  );
+
+  expect(result.files['schema.yaml']).toStrictEqual(
+    schemaArtifact.files['schema.yaml'],
+  );
+
+  const client = await generateAxiosClient({ outputClass: 'Client', spec });
+
+  expect(result.files['index.js']).toStrictEqual(client.javascript);
+
+  expect(result.files['index.d.ts']).toStrictEqual(client.declaration);
+
+  expect(result.files['package.json']).toStrictEqual(
+    `
+{
+  "name": "@lifeomic/test-service-schema",
+  "description": "The OneSchema for a test-service",
+  "testObject": {
+    "some": "value"
+  },
+  "main": "index.js",
+  "peerDependencies": {
+    "axios": "*"
+  }
+}
+`.trim(),
+  );
+});

--- a/src/generate-publishable-client.ts
+++ b/src/generate-publishable-client.ts
@@ -1,0 +1,49 @@
+import { OneSchemaDefinition } from '.';
+import { generateAxiosClient } from './generate-axios-client';
+import { generatePublishableSchema } from './generate-publishable-schema';
+
+export type GeneratePublishableClientInput = {
+  spec: OneSchemaDefinition;
+  outputClass: string;
+};
+
+export type GeneratePublishableClientOutput = {
+  /**
+   * A map of filename -> file content to generate.
+   */
+  files: Record<string, string>;
+};
+
+export const generatePublishableClient = async ({
+  spec,
+  outputClass,
+}: GeneratePublishableClientInput): Promise<GeneratePublishableClientOutput> => {
+  const { files: baseFiles } = generatePublishableSchema({ spec });
+
+  const { declaration, javascript } = await generateAxiosClient({
+    spec,
+    outputClass,
+  });
+
+  const files: Record<string, string> = {
+    ...baseFiles,
+    'index.js': javascript,
+    'index.d.ts': declaration,
+  };
+
+  if (files['package.json']) {
+    files['package.json'] = JSON.stringify(
+      {
+        ...JSON.parse(files['package.json']),
+        main: 'index.js',
+        peerDependencies: {
+          axios: '*',
+        },
+      },
+      null,
+      2,
+    );
+  }
+
+  return { files };
+};


### PR DESCRIPTION
## Motivation
Went ahead and followed up on my promise in #15. This PR adds a CLI tool for generating ready-to-ship NPM packages containing a generated client for the service.

So, this introduces an even simpler workflow for services wanting to make consumption easy:
1. Adopt `one-schema` for describing the API.
2. On `master` builds, run `generate-publishable-client` to generate the client directory.
3. Use e.g. semantic-release to continually release the client package to NPM.

As part of this work, I had to update `generate-axios-client` to generate JS + .d.ts files, instead of a .ts file.

## Example
This PR is an example of adopting this tool to continuously publish a schema: https://github.com/lifeomic/oauth-apps-service/pull/87