### PR TITLE
feat: allow synchronous route implementations

### DIFF
--- a/src/koa.ts
+++ b/src/koa.ts
@@ -23,7 +23,9 @@ export type ImplementationOf<Schema extends OneSchema<any>, State, Context> = {
           : { body: EndpointsOf<Schema>[Name]['Request'] };
       }
     >,
-  ) => Promise<EndpointsOf<Schema>[Name]['Response']>;
+  ) =>
+    | EndpointsOf<Schema>[Name]['Response']
+    | Promise<EndpointsOf<Schema>[Name]['Response']>;
 };
 
 /**


### PR DESCRIPTION
## Motivation
Currently, implementation functions _must_ return a promise. But, there's no reason not to allow synchronous implementations. Those can be useful, especially e.g. when "stubbing" an API.