### PR TITLE
fix: remove optional keys from processed json schemas

### DIFF
--- a/src/meta-schema.test.ts
+++ b/src/meta-schema.test.ts
@@ -20,7 +20,7 @@ describe('assumptions', () => {
     expect: OneSchemaDefinition;
   }[] = [
     {
-      name: 'noAdditionalPropertiesOnObjects',
+      name: 'noAdditionalPropertiesOnObjects adds additionalProperties: false to objects',
       input: {
         assumptions: {
           noAdditionalPropertiesOnObjects: true,
@@ -70,7 +70,7 @@ describe('assumptions', () => {
       },
     },
     {
-      name: 'objectPropertiesRequiredByDefault',
+      name: 'objectPropertiesRequiredByDefault marks all object properties as required by default',
       input: {
         assumptions: {
           objectPropertiesRequiredByDefault: true,
@@ -108,7 +108,7 @@ describe('assumptions', () => {
             properties: {
               id: { type: 'string' },
               message: { type: 'string' },
-              title: { type: 'string', optional: true },
+              title: { type: 'string' },
             },
           },
         },


### PR DESCRIPTION
## Motivation
Newer versions of `ajv` throw errors on encountering unexpected keys in JSONSchemas. Since we don't need these `optional` keys after performing the transform, we can + should remove them, so the output is "pure" JSONSchema.

Context: https://github.com/lifeomic/claimed-domains-service/pull/4/files#r887327717