### PR TITLE
fix: correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ implementSchema(Schema, {
   },
   introspection: {
     route: '/private/introspection',
-    serviceVersion: process.env.LIFEOMIC_SERVICE_VERSION,
+    serviceVersion: process.env.LIFEOMIC_BUILD_ID!,
   },
 });
 


### PR DESCRIPTION
## Motivation
🤦🏻 `LIFEOMIC_SERVICE_VERSION` is not a thing -- I was looking for `LIFEOMIC_BUILD_ID`.