### PR TITLE
fix!: require name parameter in generate-axios-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Then, use the `generate-axios-client` command to generate a nicely typed Axios-b
 one-schema generate-axios-client \
   --schema src/schemas/my-service.json \
   --output generated-client.ts \
+  --name MyService \
   --format
 ```
 
@@ -172,10 +173,10 @@ How to use the generated client:
 
 ```typescript
 import axios from 'axios';
-import { Client } from './generated-client';
+import { MyService } from './generated-client';
 
 // Provide any AxiosInstance, customized to your needs.
-const client = new Client(axios.create({ baseURL: 'https://my.api.com/' }));
+const client = new MyService(axios.create({ baseURL: 'https://my.api.com/' }));
 
 const response = await client.createPost({
   message: 'some-message',

--- a/src/bin/__snapshots__/cli.test.ts.snap
+++ b/src/bin/__snapshots__/cli.test.ts.snap
@@ -76,8 +76,7 @@ Options:
                  'none', or a comma-separated list containing one or more of:
                  noAdditionalPropertiesOnObjects,
                  objectPropertiesRequiredByDefault     [string] [default: \\"all\\"]
-  --className    The name of the generated client class.
-                                                    [string] [default: \\"Client\\"]
+  --name         The name of the generated client class.     [string] [required]
 
-Missing required arguments: schema, output"
+Missing required arguments: schema, output, name"
 `;

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -110,10 +110,10 @@ const program = yargs(process.argv.slice(2))
     'generate-axios-client',
     'Generates an Axios client using the specified schema and options.',
     (y) =>
-      getCommonOptions(y).option('className', {
+      getCommonOptions(y).option('name', {
         type: 'string',
         description: 'The name of the generated client class.',
-        default: 'Client',
+        demandOption: true,
       }),
     async (argv) => {
       const spec = loadSchemaFromFile(
@@ -122,7 +122,7 @@ const program = yargs(process.argv.slice(2))
       );
       const output = await generateAxiosClient({
         spec,
-        outputClass: argv.className,
+        outputClass: argv.name,
       });
 
       writeGeneratedFile(argv.output.replace('.ts', '.js'), output.javascript, {


### PR DESCRIPTION
## Motivation
By default, `generate-axios-client` is generating clients that are just named `Client`. This results in bad naming by default, and potential collisions in projects that are generating clients from multiple services.

I'd like to propose requiring a `name` parameter in this CLI, so that consumers can pick good names for the objects.