### PR TITLE
fix: correct encoding behavior

### DIFF
--- a/src/generate-axios-client.test.ts
+++ b/src/generate-axios-client.test.ts
@@ -68,14 +68,12 @@ const substituteParams = (url, params) =>
     url
   );
 
-const removePathParams = (url, params, encode) =>
+const removePathParams = (url, params) =>
   Object.entries(params)
     .filter(([key, value]) => value !== undefined)
     .reduce(
       (accum, [name, value]) =>
-        url.includes(":" + name)
-          ? accum
-          : { ...accum, [name]: encode ? encodeURIComponent(value) : value },
+        url.includes(":" + name) ? accum : { ...accum, [name]: value },
       {}
     );
 
@@ -97,7 +95,7 @@ class Client {
     return this.client.request({
       ...config,
       method: "GET",
-      params: removePathParams("/posts", data, true),
+      params: removePathParams("/posts", data),
       url: substituteParams("/posts", data),
     });
   }
@@ -106,7 +104,7 @@ class Client {
     return this.client.request({
       ...config,
       method: "PUT",
-      data: removePathParams("/posts/:id", data, false),
+      data: removePathParams("/posts/:id", data),
       url: substituteParams("/posts/:id", data),
     });
   }

--- a/src/generate-axios-client.ts
+++ b/src/generate-axios-client.ts
@@ -64,14 +64,12 @@ const substituteParams = (url, params) =>
     url
   );
 
-const removePathParams = (url, params, encode) => 
+const removePathParams = (url, params) => 
   Object.entries(params)
     .filter(([key, value]) => value !== undefined)
     .reduce(
       (accum, [name, value]) =>
-        url.includes(':' + name)
-          ? accum
-          : { ...accum, [name]: encode ? encodeURIComponent(value) : value },
+        url.includes(':' + name) ? accum : { ...accum, [name]: value },
       {}
     );
 
@@ -101,8 +99,8 @@ class ${outputClass} {
             method: '${method}',
             ${
               useQueryParams
-                ? `params: removePathParams('${url}', data, true),`
-                : `data: removePathParams('${url}', data, false),`
+                ? `params: removePathParams('${url}', data),`
+                : `data: removePathParams('${url}', data),`
             }
             url: substituteParams('${url}', data),
           })

--- a/src/integration.axios.test.ts
+++ b/src/integration.axios.test.ts
@@ -180,16 +180,15 @@ describe('integration tests', () => {
   });
 
   test('generated code URI-encodes query parameters', async () => {
-    const result = await client.listPosts({ filter: 'some/evil/string' });
+    const filter = 'some/evil/string';
+    const result = await client.listPosts({ filter });
 
     expect(mockMiddleware).toHaveBeenCalledTimes(1);
     expect(result.data).toStrictEqual({
       method: 'GET',
       path: '/posts/list',
       body: {},
-      query: {
-        filter: 'some%2Fevil%2Fstring',
-      },
+      query: { filter },
     });
   });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,34 @@
+import { Server } from 'http';
+import axios, { AxiosInstance } from 'axios';
+import Koa from 'koa';
+
+export type UseSchemaClientOptions = {
+  service: Koa;
+};
+
+export type UseServiceClientContext = {
+  client: AxiosInstance;
+};
+
+export const useServiceClient = ({ service }: UseSchemaClientOptions) => {
+  const context: UseServiceClientContext = {} as any;
+
+  let server: Server;
+
+  beforeEach(() => {
+    server = service.listen();
+
+    context.client = axios.create({
+      // In tests, we should always explicitly assert 200.
+      validateStatus: () => true,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      baseURL: `http://127.0.0.1:${(server.address() as any).port}`,
+    });
+  });
+
+  afterEach(() => {
+    server.close();
+  });
+
+  return context;
+};


### PR DESCRIPTION
## Motivation
This encoding behavior is wrong for query params. It's double-encoding the input. Two commits:
1. Migrate `integration.axios.test` to use an actual HTTP server to validate the requests from the generated client, rather than just asserting on Axios parameters.
2. Correct the bad behavior.