### PR TITLE
fix: make package public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,4 @@ jobs:
           yarn test
           yarn build
       - name: Publish
-        run: |
-          yarn semantic-release
-          npm access grant read-only lifeomic:readonly-developers '@lifeomic/one-schema'
+        run: yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "node build.js",
     "lint": "eslint .",


### PR DESCRIPTION
## Motivation
Making this package publish publicly, after discussion [here](https://lifeomic.slack.com/archives/C0137E2L8C9/p1654796924703889).

The repo is already publicly visible -- this just makes the NPM package public too.