### PR TITLE
fix: resolve refs in request schemas when validating

### DIFF
--- a/src/json-schema.ts
+++ b/src/json-schema.ts
@@ -44,3 +44,55 @@ export const transformJSONSchema = (
     }),
   );
 };
+
+/**
+ * "Resolves" any $ref entries within the provided `root` schema, using
+ * the provided `definitions`. Returns the "resolved" version of the schema.
+ *
+ * @example
+ * const schema = {
+ *   type: 'array',
+ *   items: {
+ *     $ref: '#/definitions/Item'
+ *   }
+ * }
+ *
+ * const resolved = withResolvedDefinitions(
+ *   schema,
+ *   {
+ *     Item: {
+ *       type: 'string',
+ *       description: 'An item'
+ *     }
+ *   }
+ * )
+ *
+ * console.log(resolved)
+ *
+ * // {
+ * //   type: 'array',
+ * //   items: {
+ * //     type: 'string',
+ * //     description: 'An item'
+ * //   }
+ * // }
+ */
+export const withResolvedDefinitions = (
+  root: JSONSchema4,
+  definitions: Record<string, JSONSchema4 | undefined>,
+): JSONSchema4 =>
+  transformJSONSchema(root, (schema) => {
+    if (!schema.$ref) {
+      return schema;
+    }
+
+    const resourceName = schema.$ref.split('/')[2];
+    if (!resourceName) {
+      throw new Error(`Encountered an invalid ref: ${schema.$ref}`);
+    }
+    const resource = definitions[resourceName];
+    if (!resource) {
+      throw new Error(`Encountered an invalid ref: ${schema.$ref}`);
+    }
+    return withResolvedDefinitions(resource, definitions);
+  });


### PR DESCRIPTION
## Motivation
Currently, you can side-step the standard schema validations by using a `$ref` for your request schema.

This fixes that!