### PR TITLE
fix: make body typing more deterministic

### DIFF
--- a/src/koa.test.ts
+++ b/src/koa.test.ts
@@ -51,10 +51,30 @@ test('setting a 200-level response code overrides the response', async () => {
       implementation: {
         'DELETE /post/:id': (ctx) => {
           ctx.response.status = 204;
+
+          // This comment essentially serves as a "test" that the `body` property
+          // has been removed from the `request` object.
+          // @ts-expect-error
+          ctx.request.body;
+
+          // This line serves as an implicit test that the `query` property
+          // is present on the `request` object.
+          ctx.request.query;
+
           return {};
         },
         'POST /posts': (ctx) => {
           ctx.response.status = 301;
+
+          // This line serves as an implicit test that the `body` property
+          // is present on the `request` object.
+          ctx.request.body;
+
+          // This comment essentially serves as a "test" that the `query` property
+          // has been removed from the `request` object.
+          // @ts-expect-error
+          ctx.request.query;
+
           return {};
         },
       },


### PR DESCRIPTION
## Motivation
I have continued to encounter issues with the global `declare` that this project has been using to allow correct typing of the `request.body` property.

I discovered a much cleaner solution. See the in-line comments.