### PR TITLE
feat!: use `infer` statements to better infer router state + context

### DIFF
--- a/src/integration.koa.test.ts
+++ b/src/integration.koa.test.ts
@@ -87,11 +87,11 @@ const TEST_SPEC: OneSchemaDefinition = withAssumptions({
 });
 
 const executeTest = async (
-  overrides: Partial<ImplementationConfig<any, any, any>>,
+  overrides: Partial<ImplementationConfig<any, Router>>,
   testFn: (client: AxiosInstance) => Promise<void>,
 ) => {
   const ajv = new Ajv();
-  const config: ImplementationConfig<any, any, any> = {
+  const config: ImplementationConfig<any, Router> = {
     on: new Router(),
     parse: (ctx, { schema, data }) => {
       if (ajv.validate(schema, data)) {
@@ -151,6 +151,9 @@ test('GET method', async () => {
     {
       implementation: {
         'GET /posts': (ctx) => {
+          // TypeScript isn't smart enough to determine the correct ctx.request
+          // property here.
+          // @ts-ignore
           return ctx.request.query;
         },
       },

--- a/src/koa.test.ts
+++ b/src/koa.test.ts
@@ -18,7 +18,6 @@ test('using unsupported methods throws immediately', () => {
         },
       }),
       {
-        // @ts-ignore
         on: new Router(),
         parse: () => null as any,
         implementation: {
@@ -102,4 +101,33 @@ test('setting a 200-level response code overrides the response', async () => {
   expect(createRes.status).toStrictEqual(200);
 
   server.close();
+});
+
+/**
+ * This test doesn't perform expectations -- rather, it will just
+ * cause build errors if the TypeScript doesn't apss compilation
+ */
+test('router typing is inferred correctly', () => {
+  const router = new Router<
+    { dummyStateProperty: string },
+    { dummyContextProperty: string }
+  >();
+
+  implementSchema(withAssumptions({ Endpoints: {} }), {
+    introspection: undefined,
+    parse: () => null as any,
+    on: router,
+    implementation: {
+      'GET /dummy-route': (ctx) => {
+        // assert state is extended correctly
+        ctx.state.dummyStateProperty;
+
+        // assert context is extended correctly
+        ctx.dummyContextProperty;
+      },
+    },
+  });
+
+  // perform a dummy expectation just to satisfy jest
+  expect(true).toBe(true);
 });


### PR DESCRIPTION
## Motivation
This change should result in much more deterministic inferences of the `State` and `Context` of the passed router.

**tl;dr**
_Before_, TypeScript attempted to determine the `State` + `Context` types by deciding between the passed `Router` and the passed `implementation. This could result in inconsistent behavior, and sometimes needing to explicitly override the types:

```typescript
type State = { customState: string };

const router = new Router<State>();

// sometimes, have to explicitly set these generics. super lame, since now we're
// making it explicit in two places (here, and just above on the Router) 😢
implementSchema<typeof Schema, State, {}>(..., {
  on: router,
  implementation: {
    'GET /whatever': (ctx) => {
      ctx.customState;
    }
  }
})
```

_Now_, the `State` and `Context` types are explicitly inferred from the `Router` instance. So, creating a well-typed Router will result in well-typed State every time.

```typescript
type State = { customState: string };

const router = new Router<State>();

// now, we can just set State on the router above! 🎉
implementSchema(..., {
  on: router,
  implementation: {
    'GET /whatever': (ctx) => {
      ctx.customState;
    }
  }
})
```


But, this changes types in a breaking way.