### PR TITLE
fix: generate OpenAPI v3.0.0 specs

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -174,7 +174,7 @@ const program = yargs(process.argv.slice(2))
       );
 
       const openAPISpec = toOpenAPISpec(spec, {
-        info: { version: argv.apiTitle, title: argv.apiTitle },
+        info: { version: argv.apiVersion, title: argv.apiTitle },
       });
 
       const output =

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -87,14 +87,14 @@ describe('toOpenAPISpec', () => {
 
     // Ensure result is a valid OpenAPI spec
     const { errors } = new OpenAPIValidator({
-      version: '3.1.0',
+      version: '3.0.0',
     }).validate(result);
 
     expect(errors).toHaveLength(0);
 
     // Assert on specific response.
     expect(result).toStrictEqual({
-      openapi: '3.1.0',
+      openapi: '3.0.0',
       info: { title: 'test title', version: '1.2.3' },
       components: {
         schemas: {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,4 +1,4 @@
-import type { OpenAPIV3_1 } from 'openapi-types';
+import type { OpenAPIV3 } from 'openapi-types';
 import type { OneSchemaDefinition } from './types';
 import { deepCopy } from './generate-endpoints';
 import { validateSchema } from './meta-schema';
@@ -21,14 +21,14 @@ const getPathParameters = (koaPath: string) =>
 export const toOpenAPISpec = (
   schema: OneSchemaDefinition,
   config: {
-    info: OpenAPIV3_1.InfoObject;
+    info: OpenAPIV3.InfoObject;
   },
-): OpenAPIV3_1.Document => {
+): OpenAPIV3.Document => {
   validateSchema(schema);
 
   // 1. Declare the document. We'll build it as we go.
-  const openAPIDocument: OpenAPIV3_1.Document = {
-    openapi: '3.1.0',
+  const openAPIDocument: OpenAPIV3.Document = {
+    openapi: '3.0.0',
     info: config.info,
     components: {},
     paths: {},
@@ -52,7 +52,7 @@ export const toOpenAPISpec = (
   ] of Object.entries(Endpoints)) {
     const [method, path] = endpoint.split(' ');
 
-    const operation: OpenAPIV3_1.OperationObject = {
+    const operation: OpenAPIV3.OperationObject = {
       operationId: Name,
       responses: {
         '200': {
@@ -69,14 +69,14 @@ export const toOpenAPISpec = (
       },
     };
 
-    const parameters: OpenAPIV3_1.ParameterObject[] = getPathParameters(
-      path,
-    ).map((name) => ({
-      name,
-      in: 'path',
-      schema: { type: 'string' },
-      required: true,
-    }));
+    const parameters: OpenAPIV3.ParameterObject[] = getPathParameters(path).map(
+      (name) => ({
+        name,
+        in: 'path',
+        schema: { type: 'string' },
+        required: true,
+      }),
+    );
 
     if (Request) {
       if (['GET', 'DELETE'].includes(method)) {


### PR DESCRIPTION
## Motivation
Two:
- Generate OpenAPI v3.0.0 specs instead of v3.1.0. Our current API reference site uses v3.0.0, so this ensures that we don't accidentally use any v3.1.0 features.
- Fix an OpenAPI spec generation bug. Called out below.