### PR TITLE
fix: stop adding newlines to yaml output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 coverage
 .vscode
 dist/
-src/test-generated.js
-src/test-generated.d.ts
+src/test-schema.json
+src/test-generated.*

--- a/src/bin/cli.test.ts
+++ b/src/bin/cli.test.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { tmpNameSync } from 'tmp';
+import { OneSchemaDefinition } from '../types';
 
 const executeCLI = (command: string): string => {
   try {
@@ -12,6 +13,15 @@ const executeCLI = (command: string): string => {
   } catch (err) {
     return err.stderr.toString();
   }
+};
+
+/**
+ * Writes the `schema`, and returns its filepath.
+ */
+const writeSchema = (schema: OneSchemaDefinition): string => {
+  const path = `${__dirname}/../test-schema.json`;
+  writeFileSync(path, JSON.stringify(schema, null, 2), { encoding: 'utf8' });
+  return path;
 };
 
 describe('schema validation snapshots', () => {
@@ -76,5 +86,59 @@ describe('input validation snapshots', () => {
       const result = executeCLI(input);
       expect(result.trim()).toMatchSnapshot();
     });
+  });
+});
+
+describe('generate-open-api-spec', () => {
+  it('does not create new newlines when serializing + deserializing to YAML', () => {
+    const description =
+      'This is a long description that might go over the js-yaml default line length.\nIt also contains newlines.\n\nLots of newlines!';
+
+    const path = writeSchema({
+      Endpoints: {
+        'GET /something': {
+          Name: 'getSomething',
+          Description: description,
+          Response: {
+            type: 'object',
+          },
+        },
+      },
+    });
+
+    const output = `${__dirname}/../test-generated.yaml`;
+
+    executeCLI(
+      `generate-open-api-spec --schema '${path}' --output '${output}' --apiTitle 'test title'`,
+    );
+
+    const yamlContent = readFileSync(output, { encoding: 'utf8' });
+
+    expect(yamlContent.trim()).toStrictEqual(
+      `
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: test title
+components: {}
+paths:
+  /something:
+    get:
+      operationId: getSomething
+      description: |-
+        This is a long description that might go over the js-yaml default line length.
+        It also contains newlines.
+
+        Lots of newlines!
+      responses:
+        "200":
+          description: A successful response
+          content:
+            application/json:
+              schema:
+                additionalProperties: false
+                type: object
+`.trim(),
+    );
   });
 });

--- a/src/bin/cli.test.ts
+++ b/src/bin/cli.test.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import { tmpNameSync } from 'tmp';
 import { OneSchemaDefinition } from '../types';
+import * as yaml from 'js-yaml';
 
 const executeCLI = (command: string): string => {
   try {
@@ -114,6 +115,7 @@ describe('generate-open-api-spec', () => {
 
     const yamlContent = readFileSync(output, { encoding: 'utf8' });
 
+    // Assert the output looks right.
     expect(yamlContent.trim()).toStrictEqual(
       `
 openapi: 3.0.0
@@ -139,6 +141,13 @@ paths:
                 additionalProperties: false
                 type: object
 `.trim(),
+    );
+
+    // Assert the output deserializes correctly.
+    const openapi: any = yaml.load(yamlContent);
+
+    expect(openapi.paths['/something'].get.description).toStrictEqual(
+      description,
     );
   });
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -182,9 +182,9 @@ const program = yargs(process.argv.slice(2))
           ? dump(openAPISpec, {
               /**
                * Without this, js-yaml will default to a line width of 80 and use
-               * "line folding". While this should not actually affect serialization
-               * or deserialization, it can result in ugly-looking output that contains
-               * newlines in unexpected places.
+               * the "folded" multiline style. While this should not actually affect
+               * serialization or deserialization, it can result in ugly-looking output
+               * that contains newlines in unexpected places.
                *
                * This option allows us to preserve the original developer's newlines.
                */

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -179,7 +179,17 @@ const program = yargs(process.argv.slice(2))
 
       const output =
         argv.output.endsWith('.yml') || argv.output.endsWith('.yaml')
-          ? dump(openAPISpec)
+          ? dump(openAPISpec, {
+              /**
+               * Without this, js-yaml will default to a line width of 80 and use
+               * "line folding". While this should not actually affect serialization
+               * or deserialization, it can result in ugly-looking output that contains
+               * newlines in unexpected places.
+               *
+               * This option allows us to preserve the original developer's newlines.
+               */
+              lineWidth: -1,
+            })
           : JSON.stringify(openAPISpec, null, 2);
 
       writeGeneratedFile(argv.output, output, { format: argv.format });


### PR DESCRIPTION
## Motivation
See the in-line comment re: YAML "line folding".

To confirm the change is doing what we want, you can look at the failing test output on the first commit of this PR.