### PR TITLE
fix: set endpoint description in correct place in OpenAPI spec

### DIFF
--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -117,6 +117,7 @@ describe('toOpenAPISpec', () => {
         '/posts': {
           get: {
             operationId: 'getPosts',
+            description: 'This endpoint has a description',
             parameters: [
               {
                 in: 'query',
@@ -134,7 +135,7 @@ describe('toOpenAPISpec', () => {
             ],
             responses: {
               '200': {
-                description: 'This endpoint has a description',
+                description: 'A successful response',
                 content: {
                   'application/json': {
                     schema: {
@@ -171,7 +172,7 @@ describe('toOpenAPISpec', () => {
             },
             responses: {
               '200': {
-                description: 'None',
+                description: 'A successful response',
                 content: {
                   'application/json': {
                     schema: {
@@ -205,7 +206,7 @@ describe('toOpenAPISpec', () => {
                     },
                   },
                 },
-                description: 'None',
+                description: 'A successful response',
               },
             },
           },
@@ -223,7 +224,7 @@ describe('toOpenAPISpec', () => {
             ],
             responses: {
               '200': {
-                description: 'None',
+                description: 'A successful response',
                 content: {
                   'application/json': {
                     schema: {
@@ -264,7 +265,7 @@ describe('toOpenAPISpec', () => {
             },
             responses: {
               '200': {
-                description: 'None',
+                description: 'A successful response',
                 content: {
                   'application/json': {
                     schema: {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -54,9 +54,10 @@ export const toOpenAPISpec = (
 
     const operation: OpenAPIV3.OperationObject = {
       operationId: Name,
+      description: Description,
       responses: {
         '200': {
-          description: Description || 'None',
+          description: 'A successful response',
           content: {
             'application/json': {
               // @ts-expect-error TS detects a mismatch between the JSONSchema types


### PR DESCRIPTION
## Motivation
I accidentally put the `Description` in the wrong place in #46.