### PR TITLE
feat: introduce OneSchemaRouter as a simpler approach

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "js-yaml": "^4.1.0",
     "json-schema-to-typescript": "^10.1.5",
     "openapi-types": "^11.0.1",
-    "yargs": "^17.5.1"
+    "yargs": "^17.5.1",
+    "zod-to-json-schema": "^3.20.2",
+    "zod-validation-error": "^0.3.0"
   },
   "devDependencies": {
     "@koa/router": "^12.0.0",
@@ -52,6 +54,7 @@
     "tmp": "^0.2.1",
     "ts-jest": "^28.0.3",
     "ts-node": "^10.8.0",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.2",
+    "zod": "^3.20.2"
   }
 }

--- a/src/__snapshots__/router.test.ts.snap
+++ b/src/__snapshots__/router.test.ts.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`introspection introspecting + generating a client 1`] = `
+"/* eslint-disable */
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from \\"axios\\";
+
+export type Endpoints = {
+  \\"POST /items\\": {
+    Request: {
+      message: string;
+    };
+    PathParams: {};
+    Response: {
+      id: string;
+      message: string;
+    };
+  };
+  \\"GET /items/:id\\": {
+    Request: {
+      filter: string;
+    };
+    PathParams: {
+      id: string;
+    };
+    Response: {
+      id: string;
+      message: string;
+    };
+  };
+};
+
+export declare class Client {
+  constructor(client: AxiosInstance);
+
+  /**
+   * Executes the \`POST /items\` endpoint.
+   *
+   * @param data The request data.
+   * @param config The Axios request overrides for the request.
+   *
+   * @returns An AxiosResponse object representing the response.
+   */
+  createItem(
+    data: Endpoints[\\"POST /items\\"][\\"Request\\"] &
+      Endpoints[\\"POST /items\\"][\\"PathParams\\"],
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<Endpoints[\\"POST /items\\"][\\"Response\\"]>>;
+
+  /**
+   * Executes the \`GET /items/:id\` endpoint.
+   *
+   * @param data The request data.
+   * @param config The Axios request overrides for the request.
+   *
+   * @returns An AxiosResponse object representing the response.
+   */
+  getItem(
+    data: Endpoints[\\"GET /items/:id\\"][\\"Request\\"] &
+      Endpoints[\\"GET /items/:id\\"][\\"PathParams\\"],
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<Endpoints[\\"GET /items/:id\\"][\\"Response\\"]>>;
+
+  /**
+   * Paginates exhaustively through the provided \`request\`, using the specified
+   * \`data\`. A \`pageSize\` can be specified in the \`data\` to customize the
+   * page size for pagination.
+   */
+  paginate<T extends { nextPageToken?: string; pageSize?: string }, Item>(
+    request: (
+      data: T,
+      config?: AxiosRequestConfig
+    ) => Promise<
+      AxiosResponse<{ items: Item[]; links: { self: string; next?: string } }>
+    >,
+    data: T,
+    config?: AxiosRequestConfig
+  ): Promise<Item[]>;
+}
+"
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './koa';
 export * from './types';
+export * from './router';
 
 // We intentionally avoid exposing codegen-related modules here,
 // so that consumers don't unnecessarily bundle codegen logic

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,393 @@
+import axios, { AxiosInstance } from 'axios';
+import { Server } from 'http';
+import { v4 as uuid } from 'uuid';
+import { format } from 'prettier';
+import Koa = require('koa');
+import Router = require('@koa/router');
+import bodyparser = require('koa-bodyparser');
+import { OneSchemaRouter } from './router';
+import { z } from 'zod';
+import { generateAxiosClient } from './generate-axios-client';
+
+let server: Server | undefined = undefined;
+afterEach(() => {
+  server?.close();
+});
+
+const setup = <T extends OneSchemaRouter<any, any>>(
+  expose: (router: OneSchemaRouter<{}, Router>) => T,
+): { client: AxiosInstance } => {
+  const router = expose(
+    OneSchemaRouter.create({ using: new Router(), introspection: undefined }),
+  );
+  return serve(router);
+};
+
+const serve = (
+  router: OneSchemaRouter<{}, Router>,
+): { client: AxiosInstance } => {
+  server = new Koa().use(bodyparser()).use(router.middleware()).listen();
+
+  const { port } = server.address() as any;
+
+  const client = axios.create({
+    baseURL: `http://localhost:${port}`,
+    validateStatus: () => true,
+  });
+
+  return { client };
+};
+
+test('introspection', async () => {
+  const { client } = setup(() =>
+    OneSchemaRouter.create({
+      using: new Router(),
+      introspection: { route: '/private/introspection', serviceVersion: '123' },
+    })
+      .route({
+        name: 'getSomething',
+        route: 'GET /something/:id',
+        description: 'it gets something',
+        request: z.object({ filter: z.string() }),
+        response: z.object({ message: z.string(), id: z.string() }),
+      })
+      .implement('GET /something/:id', () => ({ id: '', message: '' }))
+      .route({
+        name: 'createSomething',
+        route: 'POST /something',
+        description: 'it creates something',
+        request: z.object({ message: z.string() }),
+        response: z.object({ message: z.string(), id: z.string() }),
+      })
+      .implement('POST /something', () => ({ id: '', message: '' })),
+  );
+
+  const result = await client.get('/private/introspection');
+
+  expect(result.status).toStrictEqual(200);
+  expect(result.data).toStrictEqual({
+    serviceVersion: '123',
+    schema: {
+      Endpoints: {
+        'GET /something/:id': {
+          Description: 'it gets something',
+          Name: 'getSomething',
+          Request: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              filter: { type: 'string' },
+            },
+            required: ['filter'],
+            type: 'object',
+          },
+          Response: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              id: { type: 'string' },
+              message: { type: 'string' },
+            },
+            required: ['message', 'id'],
+            type: 'object',
+          },
+        },
+        'POST /something': {
+          Description: 'it creates something',
+          Name: 'createSomething',
+          Request: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              message: { type: 'string' },
+            },
+            required: ['message'],
+            type: 'object',
+          },
+          Response: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            additionalProperties: false,
+            properties: {
+              id: { type: 'string' },
+              message: { type: 'string' },
+            },
+            required: ['message', 'id'],
+            type: 'object',
+          },
+        },
+      },
+    },
+  });
+});
+
+describe('type inference', () => {
+  test('type inference for implementation return type', () => {
+    setup((router) =>
+      router
+        .route({
+          name: 'getItem',
+          route: 'GET /items/:id',
+          request: z.object({ message: z.string() }),
+          response: z.object({
+            id: z.string(),
+            message: z.string(),
+          }),
+        })
+        .implement(
+          'GET /items/:id',
+          // This should not compile, since we're returning an object that does not match the schema.
+          // @ts-expect-error
+          () => ({ bogus: 'data' }),
+        ),
+    );
+  });
+
+  test('type inference for POST body + params', () => {
+    setup((router) =>
+      router
+        .route({
+          name: 'createItem',
+          route: 'POST /items/:id',
+          request: z.object({ message: z.string() }),
+          response: z.object({ message: z.string() }),
+        })
+        .implement('POST /items/:id', (ctx) => {
+          // this statement helps us validate that the body is typed correctly
+          ctx.request.body.message.trim();
+
+          // This expect-error helps us confirm that the query is not on the ctx.
+          // @ts-expect-error
+          ctx.request.query;
+
+          // this statement helps us validate that the params are typed correctly
+          ctx.params.id.trim();
+
+          return ctx.request.body;
+        }),
+    );
+  });
+
+  test('type inference for GET body + params', () => {
+    setup((router) =>
+      router
+        .route({
+          name: 'get',
+          route: 'GET /items/:id',
+          request: z.object({ message: z.string() }),
+          response: z.object({ message: z.string() }),
+        })
+        .implement('GET /items/:id', (ctx) => {
+          // this statement helps us validate that the body is typed correctly
+          ctx.request.query.message.trim();
+
+          // This expect-error helps us confirm that the query is not on the ctx.
+          // @ts-expect-error
+          ctx.request.body;
+
+          // this statement helps us validate that the params are typed correctly
+          ctx.params.id.trim();
+
+          return ctx.request.query;
+        }),
+    );
+  });
+});
+
+describe('input validation', () => {
+  (['POST', 'PUT', 'PATCH'] as const).forEach((method) => {
+    test(`rejects requests that do not match the schema for ${method} requests`, async () => {
+      const { client } = setup((router) =>
+        router
+          .route({
+            name: 'createItem',
+            route: `${method} /items`,
+            request: z.object({ message: z.string() }),
+            response: z.object({ message: z.string() }),
+          })
+          .implement(`${method} /items`, () => ({ message: '' })),
+      );
+
+      const { status, data } = await client.request({
+        method,
+        url: '/items',
+        data: { bogus: 'value' },
+      });
+
+      expect(status).toStrictEqual(400);
+      expect(data).toStrictEqual(
+        'The request input did not conform to the required schema: Required at "message"',
+      );
+    });
+  });
+
+  (['GET', 'DELETE'] as const).forEach((method) => {
+    test(`rejects requests that do not match the schema for ${method} requests`, async () => {
+      const { client } = setup((router) =>
+        router
+          .route({
+            name: 'getItem',
+            route: `${method} /items`,
+            request: z.object({ message: z.string() }),
+            response: z.object({ message: z.string() }),
+          })
+          .implement(`${method} /items`, () => ({ message: '' })),
+      );
+
+      const { status, data } = await client.request({
+        method,
+        url: '/items',
+        params: { bogus: 'value' },
+      });
+
+      expect(status).toStrictEqual(400);
+      expect(data).toStrictEqual(
+        'The request input did not conform to the required schema: Required at "message"',
+      );
+    });
+  });
+
+  test('error messages when there are multiple validation errors', async () => {
+    const { client } = setup((router) =>
+      router
+        .route({
+          name: 'createItem',
+          route: 'POST /items',
+          request: z.object({ message: z.string(), private: z.boolean() }),
+          response: z.object({ message: z.string() }),
+        })
+        .implement('POST /items', () => ({ message: '' })),
+    );
+
+    const { status, data } = await client.request({
+      method: 'POST',
+      url: '/items',
+      data: { bogus: 'value' },
+    });
+
+    expect(status).toStrictEqual(400);
+    expect(data).toStrictEqual(
+      'The request input did not conform to the required schema: Required at "message"; Required at "private"',
+    );
+  });
+});
+
+describe('implementations', () => {
+  (['POST', 'PUT', 'PATCH'] as const).forEach((method) => {
+    test(`rejects requests that do not match the schema for ${method} requests`, async () => {
+      const { client } = setup((router) =>
+        router
+          .route({
+            name: 'createItem',
+            route: `${method} /items`,
+            request: z.object({ message: z.string() }),
+            response: z.object({ message: z.string() }),
+          })
+          .implement(`${method} /items`, (ctx) => ({
+            message: ctx.request.body.message + '-response',
+          })),
+      );
+
+      const message = uuid();
+
+      const { status, data } = await client.request({
+        method,
+        url: '/items',
+        data: { message },
+      });
+
+      expect(status).toStrictEqual(200);
+      expect(data).toStrictEqual({ message: `${message}-response` });
+    });
+  });
+
+  (['GET', 'DELETE'] as const).forEach((method) => {
+    test(`rejects requests that do not match the schema for ${method} requests`, async () => {
+      const { client } = setup((router) =>
+        router
+          .route({
+            name: 'createItem',
+            route: `${method} /items`,
+            request: z.object({ message: z.string() }),
+            response: z.object({ message: z.string() }),
+          })
+          .implement(`${method} /items`, (ctx) => ({
+            message: ctx.request.query.message + '-response',
+          })),
+      );
+
+      const message = uuid();
+
+      const { status, data } = await client.request({
+        method,
+        url: '/items',
+        params: { message },
+      });
+
+      expect(status).toStrictEqual(200);
+      expect(data).toStrictEqual({ message: `${message}-response` });
+    });
+  });
+});
+
+describe('introspection', () => {
+  test('introspecting + generating a client', async () => {
+    const { client } = serve(
+      OneSchemaRouter.create({
+        using: new Router(),
+        introspection: {
+          route: '/private/introspection',
+          serviceVersion: '123',
+        },
+      })
+        .route({
+          name: 'createItem',
+          route: 'POST /items',
+          request: z.object({ message: z.string() }),
+          response: z.object({ id: z.string(), message: z.string() }),
+        })
+        .implement('POST /items', (ctx) => ({
+          id: 'something',
+          message: ctx.request.body.message + '-response',
+        }))
+        .route({
+          route: 'GET /items/:id',
+          name: 'getItem',
+          request: z.object({
+            filter: z.string(),
+          }),
+          response: z.object({ id: z.string(), message: z.string() }),
+        })
+        .implement('GET /items/:id', (ctx) => ({
+          id: ctx.params.id,
+          message: ctx.request.query.filter + '-response',
+        })),
+    );
+
+    const { status, data } = await client.request({
+      method: 'GET',
+      url: '/private/introspection',
+    });
+
+    expect(status).toStrictEqual(200);
+    expect(data).toStrictEqual({
+      serviceVersion: '123',
+      schema: {
+        Endpoints: expect.objectContaining({
+          'POST /items': expect.anything(),
+          'GET /items/:id': expect.anything(),
+        }),
+      },
+    });
+
+    const clientCode = await generateAxiosClient({
+      spec: data.schema,
+      outputClass: 'Client',
+    });
+
+    const formattedDeclaration = format(clientCode.declaration, {
+      parser: 'typescript',
+    });
+
+    expect(formattedDeclaration).toMatchSnapshot();
+  });
+});

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -44,7 +44,7 @@ test('introspection', async () => {
       using: new Router(),
       introspection: { route: '/private/introspection', serviceVersion: '123' },
     })
-      .route({
+      .declare({
         name: 'getSomething',
         route: 'GET /something/:id',
         description: 'it gets something',
@@ -52,7 +52,7 @@ test('introspection', async () => {
         response: z.object({ message: z.string(), id: z.string() }),
       })
       .implement('GET /something/:id', () => ({ id: '', message: '' }))
-      .route({
+      .declare({
         name: 'createSomething',
         route: 'POST /something',
         description: 'it creates something',
@@ -124,7 +124,7 @@ describe('type inference', () => {
   test('type inference for implementation return type', () => {
     setup((router) =>
       router
-        .route({
+        .declare({
           name: 'getItem',
           route: 'GET /items/:id',
           request: z.object({ message: z.string() }),
@@ -145,7 +145,7 @@ describe('type inference', () => {
   test('type inference for POST body + params', () => {
     setup((router) =>
       router
-        .route({
+        .declare({
           name: 'createItem',
           route: 'POST /items/:id',
           request: z.object({ message: z.string() }),
@@ -170,7 +170,7 @@ describe('type inference', () => {
   test('type inference for GET body + params', () => {
     setup((router) =>
       router
-        .route({
+        .declare({
           name: 'get',
           route: 'GET /items/:id',
           request: z.object({ message: z.string() }),
@@ -198,7 +198,7 @@ describe('input validation', () => {
     test(`rejects requests that do not match the schema for ${method} requests`, async () => {
       const { client } = setup((router) =>
         router
-          .route({
+          .declare({
             name: 'createItem',
             route: `${method} /items`,
             request: z.object({ message: z.string() }),
@@ -224,7 +224,7 @@ describe('input validation', () => {
     test(`rejects requests that do not match the schema for ${method} requests`, async () => {
       const { client } = setup((router) =>
         router
-          .route({
+          .declare({
             name: 'getItem',
             route: `${method} /items`,
             request: z.object({ message: z.string() }),
@@ -249,7 +249,7 @@ describe('input validation', () => {
   test('error messages when there are multiple validation errors', async () => {
     const { client } = setup((router) =>
       router
-        .route({
+        .declare({
           name: 'createItem',
           route: 'POST /items',
           request: z.object({ message: z.string(), private: z.boolean() }),
@@ -276,7 +276,7 @@ describe('implementations', () => {
     test(`rejects requests that do not match the schema for ${method} requests`, async () => {
       const { client } = setup((router) =>
         router
-          .route({
+          .declare({
             name: 'createItem',
             route: `${method} /items`,
             request: z.object({ message: z.string() }),
@@ -304,7 +304,7 @@ describe('implementations', () => {
     test(`rejects requests that do not match the schema for ${method} requests`, async () => {
       const { client } = setup((router) =>
         router
-          .route({
+          .declare({
             name: 'createItem',
             route: `${method} /items`,
             request: z.object({ message: z.string() }),
@@ -339,7 +339,7 @@ describe('introspection', () => {
           serviceVersion: '123',
         },
       })
-        .route({
+        .declare({
           name: 'createItem',
           route: 'POST /items',
           request: z.object({ message: z.string() }),
@@ -349,7 +349,7 @@ describe('introspection', () => {
           id: 'something',
           message: ctx.request.body.message + '-response',
         }))
-        .route({
+        .declare({
           route: 'GET /items/:id',
           name: 'getItem',
           request: z.object({

--- a/src/router.ts
+++ b/src/router.ts
@@ -57,7 +57,7 @@ export class OneSchemaRouter<
     return new OneSchemaRouter({}, config);
   }
 
-  route<
+  declare<
     Route extends RoughRoute,
     Name extends string,
     Endpoint extends RouterEndpointDefinition<Name>,

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,125 @@
+import Router from '@koa/router';
+import { z } from 'zod';
+import { fromZodError } from 'zod-validation-error';
+import zodToJsonSchema from 'zod-to-json-schema';
+import compose = require('koa-compose');
+import { IntrospectionConfig } from './koa';
+import { EndpointImplementation, implementRoute } from './koa-utils';
+import { IntrospectionResponse, OneSchemaDefinition } from './types';
+
+export type RouterEndpointDefinition<Name> = {
+  name: Name;
+  description?: string;
+  request: z.ZodType<any, any, any>;
+  response: z.ZodType<any, any, any>;
+};
+
+type Method = 'GET' | 'DELETE' | 'PUT' | 'POST' | 'PATCH';
+type RoughRoute = `${Method} ${string}`;
+
+type ZodSchema = {
+  [route: string]: RouterEndpointDefinition<string>;
+};
+
+export type OneSchemaRouterConfig<R extends Router<any, any>> = {
+  using: R;
+  introspection: IntrospectionConfig | undefined;
+};
+
+export class OneSchemaRouter<
+  Schema extends ZodSchema,
+  R extends Router<any, any>,
+> {
+  private router: R;
+
+  private constructor(
+    private schema: Schema,
+    { introspection, using: router }: OneSchemaRouterConfig<R>,
+  ) {
+    this.router = router;
+    if (introspection) {
+      router.get(introspection.route, (ctx, next) => {
+        const response: IntrospectionResponse = {
+          serviceVersion: introspection.serviceVersion,
+          schema: convertRouterSchemaToJSONSchemaStyle(this.schema),
+        };
+
+        ctx.body = response;
+        ctx.status = 200;
+        return next();
+      });
+    }
+  }
+
+  static create<R extends Router<any, any>>(
+    config: OneSchemaRouterConfig<R>,
+  ): OneSchemaRouter<{}, R> {
+    return new OneSchemaRouter({}, config);
+  }
+
+  route<
+    Route extends RoughRoute,
+    Name extends string,
+    Endpoint extends RouterEndpointDefinition<Name>,
+  >(
+    endpoint: Endpoint & { route: Route },
+  ): OneSchemaRouter<Schema & { [route in Route]: Endpoint }, R> {
+    // @ts-expect-error
+    this.schema[endpoint.route] = endpoint;
+
+    return this as any;
+  }
+
+  implement<Route extends keyof Schema & string>(
+    route: Route,
+    implementation: EndpointImplementation<
+      Route,
+      z.infer<Schema[Route]['request']>,
+      z.infer<Schema[Route]['response']>,
+      R
+    >,
+  ) {
+    const endpoint = this.schema[route];
+
+    implementRoute(
+      route,
+      this.router,
+      (ctx, data) => {
+        const res = endpoint.request.safeParse(data);
+        if (!res.success) {
+          const friendlyError = fromZodError(res.error, {
+            prefix: 'The request input did not conform to the required schema',
+          });
+          return ctx.throw(400, friendlyError.message);
+        }
+        return res.data;
+      },
+      implementation,
+    );
+
+    return this;
+  }
+
+  middleware(): Router.Middleware {
+    return compose([this.router.routes(), this.router.allowedMethods()]);
+  }
+}
+
+const convertRouterSchemaToJSONSchemaStyle = <Schema extends ZodSchema>(
+  schema: Schema,
+): OneSchemaDefinition => {
+  const oneSchema: OneSchemaDefinition = { Endpoints: {} };
+
+  for (const [endpoint, definition] of Object.entries(schema)) {
+    oneSchema.Endpoints[endpoint] = {
+      Name: definition.name,
+      Description: definition.description,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      Request: zodToJsonSchema(definition.request) as any,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      Response: zodToJsonSchema(definition.response) as any,
+    };
+  }
+
+  return oneSchema;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6583,3 +6583,18 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+zod-to-json-schema@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.20.2.tgz#576f53749fd90bbb42c99a9b8c81be234bb53cbb"
+  integrity sha512-qka3UAXmVXD8z5SHkRU89UyHp8JHJW7zc8RQCpt7QloJOn6uijwkjUm8o+M/cF1IysmKc5gxac/QeDikaQMdzQ==
+
+zod-validation-error@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-0.3.0.tgz#59118411ce24780e7a0380e89945b147cb8fe877"
+  integrity sha512-M0g8+1fgEgz6do82lA90v1IA4WXOK7TxAHqohAPktNJbTacl7tI74JS38AUWJPIJgDjUkhtEuLkUUFl3uhneyA==
+
+zod@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.2.tgz#068606642c8f51b3333981f91c0a8ab37dfc2807"
+  integrity sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==


### PR DESCRIPTION
## Motivation
**Overview**
Currently, a developer build a full-stack `one-schema`-powered application has to go through many steps to get the typing benefits across their stack. Roughly:

- In service repo, write the YAML schema for API schema in their service repo.
- In service repo, run `one-schema generate-api-types ...` to generate types for the server-side code.
- Wait for new service code to deploy.
- In client repo, run `one-schema fetch-remote-schema ...` to introspect the updated schema.
- In client repo, run `one-schema generate-axios-client ...` to generate an updated client.

This PR is focused exclusively on the first two steps:
> - In service repo, write the YAML schema for API schema in their service repo.
> - In service repo, run `one-schema generate-api-types ...` to generate types for the server-side code.

**Problems**
Within these two steps, there are multiple "sub"-pain-points that have already been reported:
- **You have to "know" a lot of things before getting started.** Any of these steps could be non-obvious to a new developer. e.g, you need to know:
  - that a YAML schema file will be required
  - that that schema file has a particular kind of shape
  - that you'll have to generate types for your service code using this schema
  - that you should probably run this^ type generation on CI
  - that you should that you need to import a particular function in your JS in order to implement your API safely

- **It's easy to make typos in a YAML file**, or to write a schema that doesn't match our "meta-schema". There is no auto-complete.

- YAML is not uncommon, but, there is no doubt: **TypeScript, not YAML, is the preferred language of the typical LifeOmic developer.** Having central API "behavior" defined in any language other than TypeScript will cause pain.


**The Good News**
TypeScript has come a long way in recent years, and the age-old problem of "runtime validation with automatic type inference" is largely solved.. The most popular open-source package that solves this problem is [`zod`](https://github.com/colinhacks/zod), which allows you to:
- define a data "schema" using TypeScript objects, and
- validate a payload against the schema, and get perfect type inference for the output.

Adopting a solution like this would theoretically allow us to reduce the first two steps of our process down to just one step:
> - ~In service repo, write the YAML schema for API schema in their service repo.~
> - ~In service repo, run `one-schema generate-api-types ...` to generate types for the server-side code.~
>
> - In service repo, define your API using Zod schemas, and write implementations in the same file/code.

How this improves our flow:
- YAML is removed from the flow entirely, removing all the YAML-related pain points.
- The number of "things to know" is reduced dramatically. A developer could just start importing code and largely discover the API themselves.
- Changes to Zod schemas will reflect updated types immediately (no codegen required), which means faster developer cycle.

This PR introduces a solution to support a Zod-based workflow.

## Changes
- Introduce `OneSchemaRouter`, a new TypeScript object that can be used to declare an API using the Zod-based workflow and get full type safety. This API is largely inspired by [`tRPC`](https://trpc.io/).
- Retain support for the introspection workflow by serializing Zod schemas into JSON schemas at introspection-time, using [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema).

New/updated documentation to support these^ changes will be added in #55.