### PR TITLE
fix: use open-source channel to report failures

### DIFF
--- a/.github/lifeomic-probot.yml
+++ b/.github/lifeomic-probot.yml
@@ -1,5 +1,5 @@
 enforceSemanticCommits: true
 reportWorkflowFailures:
   Release:
-    # This is #preventia-dev
-    slackChannel: C03AS9T658R
+    # This is #open-source
+    slackChannel: C04928K3H5Z


### PR DESCRIPTION
## Motivation
This is the preferred reporting channel for open source packages.