### PR TITLE
fix: always inline reused schemas when introspecting

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -127,9 +127,13 @@ const convertRouterSchemaToJSONSchemaStyle = <Schema extends ZodSchema>(
       // The JSONSchema types are very slightly different between packages. We just
       // trust that the interop will work fine, and use "as any" here.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      Request: zodToJsonSchema(definition.request) as any,
+      Request: zodToJsonSchema(definition.request, {
+        $refStrategy: 'none',
+      }) as any,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      Response: zodToJsonSchema(definition.response) as any,
+      Response: zodToJsonSchema(definition.response, {
+        $refStrategy: 'none',
+      }) as any,
     };
   }
 


### PR DESCRIPTION
## Motivation
When adopting the new `OneSchemaRouter`, I found a bug in the introspection workflow.

Out of the box, `zod-to-json-schema` will attempt to reduce duplication in the schema by identifying "already seen" schemas, and using `$ref` entries to essentially reflect variable reuse.

However, this does not work well in the `one-schema` context, and the end result is a `one-schema` definition with incorrect/invalid `$ref` entries.

Conceptually, the idea of trying to minimize schema duplication is a good one. But, for now, I'd like to propose just disabling that behavior, and instead opting to just inline duplicated schemas.