### PR TITLE
feat: add a method for immediately getting a client for the router

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@koa/router": "^12.0.0",
     "@lifeomic/eslint-config-standards": "^2.1.1",
     "@lifeomic/typescript-config": "^1.0.3",
-    "@types/axios": "^0.14.0",
     "@types/jest": "^27.5.1",
     "@types/js-yaml": "^4.0.5",
     "@types/koa": "^2.13.4",

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -414,3 +414,44 @@ test('declaring multiple routes with the same name results in an error', () => {
     'Multiple endpoints were declared with the same name "createSomething". Each endpoint must have a unique name.',
   );
 });
+
+test('the client(...) helper', async () => {
+  const router = OneSchemaRouter.create({
+    using: new Router(),
+    introspection: undefined,
+  })
+    .declare({
+      route: 'POST /items',
+      name: 'createItem',
+      request: z.object({ id: z.string() }),
+      response: z.object({ id: z.string() }),
+    })
+    .implement('POST /items', (ctx) => ({ id: ctx.request.body.id }))
+    .declare({
+      route: 'GET /items/:id',
+      name: 'getItemById',
+      request: z.object({
+        filter: z.string(),
+      }),
+      response: z.object({ id: z.string() }),
+    })
+    .implement('GET /items/:id', (ctx) => ({
+      id: ctx.params.id + ':' + ctx.request.query.filter,
+    }));
+
+  const { client: axios } = serve(router);
+
+  const client = router.client(axios);
+
+  const getResponse = await client.getItemById({
+    id: 'some-id',
+    filter: 'some-filter',
+  });
+
+  expect(getResponse.status).toStrictEqual(200);
+  expect(getResponse.data).toStrictEqual({ id: 'some-id:some-filter' });
+
+  const postResponse = await client.createItem({ id: 'some-id' });
+  expect(postResponse.status).toStrictEqual(200);
+  expect(postResponse.data).toStrictEqual({ id: 'some-id' });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,8 +4,13 @@ import { fromZodError } from 'zod-validation-error';
 import zodToJsonSchema from 'zod-to-json-schema';
 import compose = require('koa-compose');
 import { IntrospectionConfig } from './koa';
-import { EndpointImplementation, implementRoute } from './koa-utils';
+import {
+  EndpointImplementation,
+  implementRoute,
+  PathParamsOf,
+} from './koa-utils';
 import { IntrospectionResponse, OneSchemaDefinition } from './types';
+import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export type RouterEndpointDefinition<Name> = {
   name: Name;
@@ -24,6 +29,13 @@ type ZodSchema = {
 export type OneSchemaRouterConfig<R extends Router<any, any>> = {
   using: R;
   introspection: IntrospectionConfig | undefined;
+};
+
+export type NamedClient<Schema extends ZodSchema> = {
+  [Route in keyof Schema as Schema[Route]['name']]: (
+    request: z.infer<Schema[Route]['request']> & PathParamsOf<Route>,
+    config?: AxiosRequestConfig,
+  ) => Promise<AxiosResponse<z.infer<Schema[Route]['response']>>>;
 };
 
 export class OneSchemaRouter<
@@ -112,6 +124,50 @@ export class OneSchemaRouter<
 
   middleware(): Router.Middleware {
     return compose([this.router.routes(), this.router.allowedMethods()]);
+  }
+
+  /**
+   * Creates a user-friendly client for the router, using the provided Axios instance.
+   */
+  client(axios: AxiosInstance): NamedClient<Schema> {
+    // Getting correct dynamic typing on this is quite complicated. For now, not worth it.
+    const client = {} as any;
+
+    const substituteParams = (path: string, payload: Record<string, any>) =>
+      Object.entries(payload).reduce(
+        (path, [name, value]) =>
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          path.replace(':' + name, encodeURIComponent(value)),
+        path,
+      );
+
+    const removePathParams = (path: string, payload: Record<string, any>) =>
+      Object.entries(payload)
+        .filter(([, value]) => value !== undefined)
+        .reduce(
+          (accum, [name, value]) =>
+            path.includes(':' + name) ? accum : { ...accum, [name]: value },
+          {},
+        );
+
+    for (const [route, endpoint] of Object.entries(this.schema)) {
+      const [method, path] = route.split(' ') as [Method, string];
+      client[endpoint.name] = (payload: any, config?: AxiosRequestConfig) => {
+        return axios.request({
+          method,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          url: substituteParams(path, payload),
+          ...(['GET', 'DELETE'].includes(method)
+            ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              { params: removePathParams(path, payload) }
+            : // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              { data: removePathParams(path, payload) }),
+          ...config,
+        });
+      };
+    }
+
+    return client;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1088,13 +1088,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/axios@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
-  integrity sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==
-  dependencies:
-    axios "*"
-
 "@types/babel__core@^7.1.14":
   version "7.1.19"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.19.tgz#7b497495b7d1b4812bdb9d02804d0576f43ee460"
@@ -1694,7 +1687,7 @@ aws-sdk@^2.1146.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
-axios@*, axios@^0.27.2:
+axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
   integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==


### PR DESCRIPTION
## Motivation
Adding a method for returning a well-typed client for a router. I think this will be helpful for quickly writing unit tests in a service.

```typescript
const router = OneSchemaRouter.create({
    using: new Router(),
    introspection: undefined,
  })
    .declare({
      route: 'GET /items/:id',
      name: 'getItemById',
      request: z.object({ filter: z.string() }),
      response: z.object({ id: z.string() }),
    });

const client = router.client({ /* axios instance */ })

await client.getItemById(...)
```