### PR TITLE
feat!: support using a custom router for introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,43 @@ const app = new Koa().use(router.middleware());
 app.listen();
 ```
 
+In case the main router requires authorization headers, and you want to query the introspection route without them, you can expose it on a custom router
+like so:
+
+```typescript
+const router = OneSchemaRouter.create({
+  using: new Router(),
+  introspection: {
+    route: '/introspection',
+    router: new Router({ prefix: '/private' }),
+    serviceVersion: process.env.LIFEOMIC_SERVICE_VERSION,
+  },
+})
+  .declare({
+    route: 'POST /items',
+    name: 'createItem',
+    request: z.object({ message: z.string() }),
+    response: z.object({ id: z.string(), message: z.string() }),
+  })
+  .declare({
+    route: 'GET /items/:id',
+    name: 'getItemById',
+    request: z.object({ filter: z.string() }),
+    response: z.object({ id: z.string(), message: z.string() }),
+  });
+
+// Be sure to expose your router's routes on a Koa app.
+import Koa from 'koa';
+
+const app = new Koa().use(router.middleware());
+
+if (router.config.instrospection.router) {
+  app.use(router.config.introspection.router.middleware());
+}
+
+app.listen();
+```
+
 Once you have routes declared, add implementations for each route. Enjoy perfect type inference and auto-complete for path parameters, query parameters, and the request body.
 
 ```typescript

--- a/src/koa.test.ts
+++ b/src/koa.test.ts
@@ -118,7 +118,7 @@ test('router typing is inferred correctly', () => {
     parse: () => null as any,
     on: router,
     implementation: {
-      'GET /dummy-route': (ctx) => {
+      'GET /dummy-route': (ctx: any) => {
         // assert state is extended correctly
         ctx.state.dummyStateProperty;
 


### PR DESCRIPTION
I'm making this change at @epeters3's request. We had a minor issue in the `patient-ml-service` repo where the main router requires LO headers, and that prevents us from getting the schema using the `one-schema fetch-remote-schema` command.