### PR TITLE
feat!: enforce response conforms to schema

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -120,7 +120,17 @@ export class OneSchemaRouter<
         }
         return res.data;
       },
-      implementation,
+      async (ctx) => {
+        const result = await implementation(ctx);
+        const res = endpoint.response.safeParse(result);
+        if (!res.success) {
+          return ctx.throw(
+            500,
+            `A response value from endpoint '${route}' did not conform to the response schema.`,
+          );
+        }
+        return res.data;
+      },
     );
 
     return this;

--- a/src/router.ts
+++ b/src/router.ts
@@ -124,10 +124,10 @@ export class OneSchemaRouter<
         const result = await implementation(ctx);
         const res = endpoint.response.safeParse(result);
         if (!res.success) {
-          return ctx.throw(
-            500,
-            `A response value from endpoint '${route}' did not conform to the response schema.`,
-          );
+          const friendlyError = fromZodError(res.error, {
+            prefix: `A response value from endpoint '${route}' did not conform to the response schema.`,
+          });
+          return ctx.throw(500, friendlyError.message);
         }
         return res.data;
       },


### PR DESCRIPTION
## Motivation
Today, `OneSchemaRouter` only provides runtime enforcement of _request_ schemas. It does _not_ validate the shape of response objects, instead relying only on type inference to enforce the correct shape.

This is effective only to a degree. It still allows for at least a few bad patterns:
- response values can have the same primitive type (and thus pass type validation), but not match the schema (e.g. you could return `'bogus'` for a `z.string().datetime()` value.
- response values can be a _superset_ of the required response type, thus allowing unintended extra fields to be returned via the API -- e.g. for a schema `{ id: z.string(); }`, a value like `{ id: string; someOtherField: number` can be returned in the API implementation _without_ causing type errors.

## Proposal
I'd like to propose addressing these two issues by using the Zod response schema to _validate_ the response object before returning it to the consumer.

**The good news**: the solution is quite simple: just parse the response value using the Zod schema. This will enforce schema correctness and (by default) strip out extra fields.

**The bad news**: this is technically a breaking change.