### PR TITLE
feat!: support modifications during parsing of inputs

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -33,10 +33,17 @@ export type OneSchemaRouterConfig<R extends Router<any, any>> = {
 
 export type NamedClient<Schema extends ZodSchema> = {
   [Route in keyof Schema as Schema[Route]['name']]: (
-    request: z.infer<Schema[Route]['request']> & PathParamsOf<Route>,
+    request: z.input<Schema[Route]['request']> & PathParamsOf<Route>,
     config?: AxiosRequestConfig,
   ) => Promise<AxiosResponse<z.infer<Schema[Route]['response']>>>;
 };
+
+export type NamedClientFor<Router> = Router extends OneSchemaRouter<
+  infer Schema,
+  any
+>
+  ? NamedClient<Schema>
+  : never;
 
 export class OneSchemaRouter<
   Schema extends ZodSchema,
@@ -100,7 +107,7 @@ export class OneSchemaRouter<
     route: Route,
     implementation: EndpointImplementation<
       Route,
-      z.infer<Schema[Route]['request']>,
+      z.output<Schema[Route]['request']>,
       z.infer<Schema[Route]['response']>,
       R
     >,


### PR DESCRIPTION
## Motivation
This PR adds first-class support for using Zod effects on request schemas. A simple motivating use case:

Most LifeOmic APIs that support paging use a common query parameter called `pageSize`. Consider this implementation function:

```typescript
const impl: (ctx) => {
  // This is a string, because Koa automatically deserializes query parameters as strings.
  ctx.request.query.pageSize;
}
```

By allowing our custom handlers to _replace_ the `ctx.request.query` properties, we can allow transforms when parsing. e.g.

```typescript
const request = z.object({
  // This coercion can now actually be applied at runtime
  pageSize: z.coerce.number();
})

const impl: (ctx) => {
  ctx.request.query.pageSize; // number

  // Previously, ^this would be typed as a `number`, but would actually be a `string` at runtime
}
```