### PR TITLE
fix(PML-222): unexpected type in generated openapi spec

### DIFF
--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -29,6 +29,16 @@ const TEST_SPEC: OneSchemaDefinition = withAssumptions({
             type: 'string',
             optional: true,
           },
+          limit: {
+            description: 'page size',
+            type: 'integer',
+            optional: true,
+          },
+          updatedAt: {
+            description: 'epoch time',
+            type: 'number',
+            optional: true,
+          },
         },
       },
       Response: {
@@ -131,6 +141,20 @@ describe('toOpenAPISpec', () => {
                 name: 'filter',
                 required: false,
                 schema: { type: 'string' },
+              },
+              {
+                in: 'query',
+                description: 'page size',
+                name: 'limit',
+                required: false,
+                schema: { type: 'integer' },
+              },
+              {
+                in: 'query',
+                description: 'epoch time',
+                name: 'updatedAt',
+                required: false,
+                schema: { type: 'number' },
               },
             ],
             responses: {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -2,6 +2,7 @@ import type { OpenAPIV3 } from 'openapi-types';
 import type { OneSchemaDefinition } from './types';
 import { deepCopy } from './generate-endpoints';
 import { validateSchema } from './meta-schema';
+import { JSONSchema4 } from 'json-schema';
 
 /**
  * Converts e.g. `/users/:id/profile` to `/users/{id}/profile`.
@@ -17,6 +18,24 @@ const getPathParameters = (koaPath: string) =>
     .split('/')
     .filter((part) => part.startsWith(':'))
     .map((part) => part.slice(1));
+
+/**
+ * @param schema json schema object
+ * @return supported openapi schema object type
+ */
+const getSchemaObjectType = (
+  schema: JSONSchema4,
+): OpenAPIV3.NonArraySchemaObjectType => {
+  // TODO supports more types from JSON schema
+  switch (schema.type) {
+    case 'integer':
+      return 'integer';
+    case 'number':
+      return 'number';
+    default:
+      return 'string';
+  }
+};
 
 export const toOpenAPISpec = (
   schema: OneSchemaDefinition,
@@ -87,7 +106,7 @@ export const toOpenAPISpec = (
             in: 'query',
             name,
             description: schema.description,
-            schema: { type: 'string' },
+            schema: { type: getSchemaObjectType(schema) },
             required:
               Array.isArray(Request.required) &&
               Request.required.includes(name),


### PR DESCRIPTION
looks like `type: integer` or `type: number` is not supported yet when generating openapi spec

this blocks https://github.com/lifeomic/patient-ml-service/pull/174