### PR TITLE
fix: further improve OpenAPI query schema support

### DIFF
--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -133,28 +133,37 @@ describe('toOpenAPISpec', () => {
                 in: 'query',
                 name: 'sort',
                 required: true,
-                schema: { type: 'string' },
+                schema: { enum: ['asc', 'desc'] },
               },
               {
                 in: 'query',
                 description: 'A filter to apply to posts',
                 name: 'filter',
                 required: false,
-                schema: { type: 'string' },
+                schema: {
+                  type: 'string',
+                  description: 'A filter to apply to posts',
+                },
               },
               {
                 in: 'query',
                 description: 'page size',
                 name: 'limit',
                 required: false,
-                schema: { type: 'integer' },
+                schema: {
+                  type: 'integer',
+                  description: 'page size',
+                },
               },
               {
                 in: 'query',
                 description: 'epoch time',
                 name: 'updatedAt',
                 required: false,
-                schema: { type: 'number' },
+                schema: {
+                  type: 'number',
+                  description: 'epoch time',
+                },
               },
             ],
             responses: {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -2,7 +2,6 @@ import type { OpenAPIV3 } from 'openapi-types';
 import type { OneSchemaDefinition } from './types';
 import { deepCopy } from './generate-endpoints';
 import { validateSchema } from './meta-schema';
-import { JSONSchema4 } from 'json-schema';
 
 /**
  * Converts e.g. `/users/:id/profile` to `/users/{id}/profile`.
@@ -18,24 +17,6 @@ const getPathParameters = (koaPath: string) =>
     .split('/')
     .filter((part) => part.startsWith(':'))
     .map((part) => part.slice(1));
-
-/**
- * @param schema json schema object
- * @return supported openapi schema object type
- */
-const getSchemaObjectType = (
-  schema: JSONSchema4,
-): OpenAPIV3.NonArraySchemaObjectType => {
-  // TODO supports more types from JSON schema
-  switch (schema.type) {
-    case 'integer':
-      return 'integer';
-    case 'number':
-      return 'number';
-    default:
-      return 'string';
-  }
-};
 
 export const toOpenAPISpec = (
   schema: OneSchemaDefinition,
@@ -106,7 +87,10 @@ export const toOpenAPISpec = (
             in: 'query',
             name,
             description: schema.description,
-            schema: { type: getSchemaObjectType(schema) },
+            // @ts-expect-error TS detects a mismatch between the JSONSchema types
+            // between openapi-types and json-schema. Ignore and assume everything
+            // is cool.
+            schema: schema,
             required:
               Array.isArray(Request.required) &&
               Request.required.includes(name),


### PR DESCRIPTION
## Motivation
See this thread from #73 for more context: https://github.com/lifeomic/one-schema/pull/73#discussion_r1261593666.

As evidenced by the modified test, this change expands on #73 to add generalized support for arbitrarily complicated query parameter schemas.