### PR TITLE
feat: optional openapi schema introspection

### DIFF
--- a/src/introspection.ts
+++ b/src/introspection.ts
@@ -1,0 +1,50 @@
+import {
+  IntrospectionConfig,
+  IntrospectionResponse,
+  OneSchemaDefinition,
+} from './types';
+import type Router from '@koa/router';
+import { toOpenAPISpec } from './openapi';
+
+export const addIntrospection = (
+  introspection: IntrospectionConfig,
+  /**
+   * A function that returns the latest schema for the service. We need
+   * to use a function because a `OneSchemaRouter`'s schema does not
+   * fully exist yet during its constructor call, which is when this function
+   * is executed. So any time the introspect route is called, the most
+   * up-to-date schema will be returned.
+   */
+  getSchema: () => OneSchemaDefinition,
+  /**
+   * The service's default router that all the endpoints are
+   * declared on.
+   */
+  router: Router<any, any>,
+) => {
+  const introRouter = introspection.router || router;
+  introRouter.get(introspection.route, (ctx, next) => {
+    const response: IntrospectionResponse = {
+      schema: getSchema(),
+      serviceVersion: introspection.serviceVersion,
+    };
+
+    ctx.body = response;
+    ctx.status = 200;
+    return next();
+  });
+  if (introspection.openApi) {
+    const { info } = introspection.openApi;
+    introRouter.get(introspection.openApi.route, (ctx, next) => {
+      const response = toOpenAPISpec(getSchema(), {
+        info: {
+          ...info,
+          version: introspection.serviceVersion,
+        },
+      });
+      ctx.body = response;
+      ctx.status = 200;
+      return next();
+    });
+  }
+};

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,14 +3,14 @@ import { z } from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import zodToJsonSchema from 'zod-to-json-schema';
 import compose = require('koa-compose');
-import { IntrospectionConfig } from './koa';
 import {
   EndpointImplementation,
   implementRoute,
   PathParamsOf,
 } from './koa-utils';
-import { IntrospectionResponse, OneSchemaDefinition } from './types';
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { addIntrospection } from './introspection';
+import { IntrospectionConfig, OneSchemaDefinition } from './types';
 
 export type RouterEndpointDefinition<Name> = {
   name: Name;
@@ -57,20 +57,12 @@ export class OneSchemaRouter<
   ) {
     const { introspection, using: router } = config;
     this.router = router;
-
     if (introspection) {
-      const introRouter = introspection.router || router;
-
-      introRouter.get(introspection.route, (ctx, next) => {
-        const response: IntrospectionResponse = {
-          serviceVersion: introspection.serviceVersion,
-          schema: convertRouterSchemaToJSONSchemaStyle(this.schema),
-        };
-
-        ctx.body = response;
-        ctx.status = 200;
-        return next();
-      });
+      addIntrospection(
+        introspection,
+        () => convertRouterSchemaToJSONSchemaStyle(this.schema),
+        router,
+      );
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
+import type Router from '@koa/router';
 import type { JSONSchema4 } from 'json-schema';
+import type { OpenAPIV3 } from 'openapi-types';
 
 export type EndpointDefinition = {
   Name: string;
@@ -39,6 +41,40 @@ export type OneSchema<Endpoints extends GeneratedEndpointsType> =
 export type EndpointsOf<Schema extends OneSchema<any>> = NonNullable<
   Schema['__endpoints_type__']
 >;
+
+export type IntrospectionConfig = {
+  /**
+   * A route at which to serve the introspection request on the implementing
+   * Router object.
+   *
+   * A GET method will be supported on this route, and will return introspection data.
+   */
+  route: string;
+  /**
+   * If provided, an endpoint for returning the OpenAPI schema for the implementing router
+   * will be set up.
+   */
+  openApi?: {
+    /**
+     * A route at which to serve the OpenAPI schema for the implementing router object.
+     *
+     * A GET method will be supported on this route, and will return the OpenAPI schema.
+     */
+    route: string;
+    /**
+     * API metadata info to include in the returned OpenAPI schema.
+     */
+    info: Omit<OpenAPIV3.InfoObject, 'version'>;
+  };
+  /**
+   * The current version of the service, served as part of introspection.
+   */
+  serviceVersion: string;
+  /**
+   * An optional alternative router to use for the introspection routes.
+   */
+  router?: Router<any, any>;
+};
 
 export type IntrospectionResponse = {
   schema: OneSchemaDefinition;


### PR DESCRIPTION
You can now optionally configure an OpenAPI introspection endpoint for your `one-schema` service. Specifically, you can add an `openapi` field to your `introspection` config in this way:

```typescript
OneSchemaRouter.create({
  using: new Router(),
  introspection: {
    route: "/private/introspection",
    serviceVersion: "123",
    openApi: {
      route: "/private/openapi",
      info: {
        title: "My Service",
      },
    },
  },
});
```

The above code will allow a consumer to fetch the OpenAPI schema for this service by calling the `/private/openapi` route. The `info` block is the OpenAPI [schema metadata](https://swagger.io/specification/#info-object) for the service.