### PR TITLE
feat: support converting from openapi -> one-schema

### DIFF
--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -1,7 +1,8 @@
 import OpenAPIValidator from 'openapi-schema-validator';
 import { withAssumptions } from './meta-schema';
-import { toOpenAPISpec } from './openapi';
+import { fromOpenAPISpec, toOpenAPISpec } from './openapi';
 import { OneSchemaDefinition } from './types';
+import { OpenAPIV3 } from 'openapi-types';
 
 const TEST_SPEC: OneSchemaDefinition = withAssumptions({
   Resources: {
@@ -311,6 +312,325 @@ describe('toOpenAPISpec', () => {
           },
         },
       },
+    });
+  });
+});
+
+describe('fromOpenAPISpec', () => {
+  test('simple case', () => {
+    const result = fromOpenAPISpec({
+      openapi: '3.0.0',
+      info: { title: 'test title', version: '1.2.3' },
+      paths: {
+        '/posts': {
+          get: {
+            operationId: 'getPosts',
+            description: 'This endpoint has a description',
+            parameters: [
+              {
+                in: 'query',
+                name: 'sort',
+                required: true,
+                schema: { enum: ['asc', 'desc'] },
+              },
+              {
+                in: 'query',
+                description: 'A filter to apply to posts',
+                name: 'filter',
+                required: false,
+              },
+              {
+                in: 'query',
+                description: 'page size',
+                name: 'limit',
+                required: false,
+                schema: {
+                  type: 'integer',
+                  description: 'page size',
+                },
+              },
+              {
+                in: 'query',
+                description: 'epoch time',
+                name: 'updatedAt',
+                required: false,
+                schema: {
+                  type: 'number',
+                  description: 'epoch time',
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'A successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                          id: { type: 'number' },
+                          message: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/posts/{id}': {
+          put: {
+            operationId: 'putPost',
+            description: 'Put a post',
+            parameters: [
+              {
+                in: 'path',
+                name: 'id',
+                required: true,
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    additionalProperties: false,
+                    properties: {
+                      message: {
+                        type: 'string',
+                      },
+                    },
+                    required: ['message'],
+                    type: 'object',
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'A successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      additionalProperties: false,
+                      properties: {
+                        id: { type: 'number' },
+                        message: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Assert on specific response.
+    expect(result).toStrictEqual({
+      Resources: {},
+      Endpoints: {
+        'GET /posts': {
+          Name: 'getPosts',
+          Description: 'This endpoint has a description',
+          Request: {
+            type: 'object',
+            required: ['sort'],
+            additionalProperties: false,
+            properties: {
+              sort: {
+                enum: ['asc', 'desc'],
+              },
+              filter: {
+                description: 'A filter to apply to posts',
+                type: 'string',
+              },
+              limit: {
+                description: 'page size',
+                type: 'integer',
+              },
+              updatedAt: {
+                description: 'epoch time',
+                type: 'number',
+              },
+            },
+          },
+          Response: {
+            type: 'array',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                id: { type: 'number' },
+                message: { type: 'string' },
+              },
+            },
+          },
+        },
+        'PUT /posts/:id': {
+          Name: 'putPost',
+          Description: 'Put a post',
+          Request: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['message'],
+            properties: {
+              message: { type: 'string' },
+            },
+          },
+          Response: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              id: { type: 'number' },
+              message: { type: 'string' },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  describe('error scenarios', () => {
+    const SCENARIOS: {
+      expectedError: string;
+      paths: OpenAPIV3.PathsObject;
+    }[] = [
+      {
+        expectedError: 'No operationId on path.',
+        paths: {
+          '/posts': { get: { responses: {} } },
+        },
+      },
+      {
+        expectedError: 'No success response found for operation: getPosts',
+        paths: {
+          '/posts': {
+            get: {
+              operationId: 'getPosts',
+              responses: {
+                400: { description: 'a failure response' },
+              },
+            },
+          },
+        },
+      },
+      {
+        expectedError: 'No JSON response found for operation: getPosts',
+        paths: {
+          '/posts': {
+            get: {
+              operationId: 'getPosts',
+              responses: {
+                200: { description: 'a success response' },
+              },
+            },
+          },
+        },
+      },
+      {
+        expectedError: 'No JSON response found for operation: getPosts',
+        paths: {
+          '/posts': {
+            get: {
+              operationId: 'getPosts',
+              responses: {
+                200: {
+                  description: 'a success response',
+                  content: { 'application/xml': {} },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        expectedError: 'No request body defined for operation: createPost',
+        paths: {
+          '/posts': {
+            post: {
+              operationId: 'createPost',
+              responses: {
+                200: {
+                  description: 'a success response',
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        expectedError:
+          'No request body content defined for operation: createPost',
+        paths: {
+          '/posts': {
+            post: {
+              operationId: 'createPost',
+              requestBody: {
+                $ref: '#/some/ref',
+              },
+              responses: {
+                200: {
+                  description: 'a success response',
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        expectedError: 'No JSON request body defined for operation: createPost',
+        paths: {
+          '/posts': {
+            post: {
+              operationId: 'createPost',
+              requestBody: {
+                content: { 'application/xml': {} },
+              },
+              responses: {
+                200: {
+                  description: 'a success response',
+                  content: {
+                    'application/json': {
+                      schema: {},
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    ];
+
+    SCENARIOS.forEach(({ paths, expectedError }, idx) => {
+      test(`scenario ${idx}`, () => {
+        expect(() =>
+          fromOpenAPISpec({
+            openapi: '3.0.0',
+            info: { title: 'test title', version: '1.2.3' },
+            paths,
+          }),
+        ).toThrow(expectedError);
+      });
     });
   });
 });

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,7 +1,8 @@
 import type { OpenAPIV3 } from 'openapi-types';
-import type { OneSchemaDefinition } from './types';
+import type { EndpointDefinition, OneSchemaDefinition } from './types';
 import { deepCopy } from './generate-endpoints';
 import { validateSchema } from './meta-schema';
+import { JSONSchema4 } from 'json-schema';
 
 /**
  * Converts e.g. `/users/:id/profile` to `/users/{id}/profile`.
@@ -126,4 +127,138 @@ export const toOpenAPISpec = (
 
   // This deep copy ensures that we don't prune any `undefined` values from the object.
   return deepCopy(openAPIDocument);
+};
+
+const SUPPORTED_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+type HTTPMethod = typeof SUPPORTED_METHODS[number];
+
+const translateOpenAPIPath = (path: string) =>
+  path
+    .split('/')
+    .map((part) => {
+      // Translate from "{param}" -> ":param"
+      if (part.startsWith('{') && part.endsWith('}')) {
+        return `:${part.slice(1, -1)}`;
+      }
+      return part;
+    })
+    .join('/');
+
+const toEndpointDefinition = (
+  method: HTTPMethod,
+  operation: OpenAPIV3.OperationObject,
+): EndpointDefinition => {
+  if (!operation.operationId) {
+    throw new Error('No operationId on path.');
+  }
+
+  // 1. Validate + extract the response schema.
+  const successResponse = [200, 201, 202]
+    .map((status) => operation.responses[status])
+    .find(Boolean);
+
+  if (!successResponse) {
+    throw new Error(
+      `No success response found for operation: ${operation.operationId}`,
+    );
+  }
+  // This `as` clause was already runtime-checked above.
+  const response = successResponse as OpenAPIV3.ResponseObject;
+  const jsonResponse = response.content?.['application/json'];
+  if (!jsonResponse?.schema) {
+    throw new Error(
+      `No JSON response found for operation: ${operation.operationId}`,
+    );
+  }
+
+  let requestSchema: any = {};
+  // 2a. Validate + extract the "request" schema for methods that use query params.
+  if (method === 'get' || method === 'delete') {
+    const schema = {
+      type: 'object',
+      properties: {} as Record<string, JSONSchema4>,
+      required: [] as string[],
+      additionalProperties: false,
+    };
+
+    /* istanbul ignore next */
+    const parameters = (operation.parameters ?? []).filter(
+      (param) => !('ref' in param),
+    ) as OpenAPIV3.ParameterObject[];
+
+    const queryParams = parameters.filter((param) => param.in === 'query');
+
+    for (const param of queryParams) {
+      schema.properties[param.name] = param.schema ?? {
+        type: 'string',
+        description: param.description,
+      };
+      if (param.required) {
+        schema.required.push(param.name);
+      }
+    }
+
+    requestSchema = schema;
+  } else {
+    // 2b. Validate + extract the "request" schema for methods that use bodies.
+    if (!operation.requestBody) {
+      throw new Error(
+        `No request body defined for operation: ${operation.operationId}`,
+      );
+    }
+
+    if (!('content' in operation.requestBody)) {
+      throw new Error(
+        `No request body content defined for operation: ${operation.operationId}`,
+      );
+    }
+    const jsonRequestSchema =
+      operation.requestBody.content['application/json']?.schema;
+    if (!jsonRequestSchema) {
+      throw new Error(
+        `No JSON request body defined for operation: ${operation.operationId}`,
+      );
+    }
+    requestSchema = jsonRequestSchema;
+  }
+
+  return {
+    Name: operation.operationId,
+    Description: operation.description,
+    Request: requestSchema,
+    Response: jsonResponse.schema,
+  };
+};
+
+export const fromOpenAPISpec = (
+  spec: OpenAPIV3.Document,
+): OneSchemaDefinition => {
+  // 1. Declare the schema document. We'll build it as we go.
+  const schema: OneSchemaDefinition = {
+    Resources: {},
+    Endpoints: {},
+  };
+
+  for (const path in spec.paths) {
+    const pathDef = spec.paths[path];
+    /* istanbul ignore next */
+    if (!pathDef) {
+      continue;
+    }
+
+    const oneSchemaPath = translateOpenAPIPath(path);
+    for (const method of SUPPORTED_METHODS) {
+      const operation = pathDef[method];
+      if (!operation) {
+        continue;
+      }
+      schema.Endpoints[`${method.toUpperCase()} ${oneSchemaPath}`] =
+        toEndpointDefinition(method, operation);
+    }
+  }
+
+  validateSchema(schema);
+
+  return schema;
 };


### PR DESCRIPTION
Been slowly working on this as a distraction project for some time, and I think it's in a state where it's worth putting up.

## Motivation
Today, we only support converting API schemas _from_ `one-schema` format _to_ OpenAPI format. This PR adds support for the opposite direction: turning an OpenAPI spec _into_ a `one-schema` spec.

#### Some Context
When I first wrote this package, I considered using OpenAPI as the only spec format, and eventually decided not to for several reasons. In particular:
- OpenAPI schemas are not very readable. It's a bit hard to understand "what are all the endpoints of this API" quickly.
- OpenAPI schemas were not optimized for traversal + codegen. The spec is much less restrictive than the `one-schema` format, which makes it hard to reliably generate good code from the spec.

#### So, Why This Change
Today, we deal in "one-schema" format when passing schemas over the wire (e.g. when introspecting).

To me, this seems suboptimal for several reasons:
- The "one-schema" format will be unfamiliar to all developers outside LifeOmic, and even many devs inside LifeOmic.