### PR TITLE
fix: include route description as ts comment

### DIFF
--- a/src/generate-api-types.test.ts
+++ b/src/generate-api-types.test.ts
@@ -156,6 +156,7 @@ export const Schema: OneSchema<Endpoints> = {
           Endpoints: {
             'GET /fruits': {
               Name: 'getPosts',
+              Description: 'Fetches an array of all fruits.',
               Request: {},
               Response: {
                 type: 'array',
@@ -171,6 +172,9 @@ export const Schema: OneSchema<Endpoints> = {
 import type { OneSchema } from "@lifeomic/one-schema";
 
 export type Endpoints = {
+  /**
+   * Fetches an array of all fruits.
+   */
   "GET /fruits": {
     Request: unknown;
     PathParams: {};
@@ -220,6 +224,7 @@ export const Schema: OneSchema<Endpoints> = {
   Endpoints: {
     "GET /fruits": {
       Name: "getPosts",
+      Description: "Fetches an array of all fruits.",
       Request: {},
       Response: { type: "array", items: { $ref: "#/definitions/Fruit" } },
     },

--- a/src/generate-axios-client.test.ts
+++ b/src/generate-axios-client.test.ts
@@ -155,6 +155,13 @@ export type Endpoints = {
       output?: string;
     };
   };
+  /**
+   * This is a long description about a field. It contains lots of very long text. Sometimes the text might be over the desired line length.
+   *
+   * It contains newlines.
+   *
+   * ## It contains markdown.
+   */
   "PUT /posts/:id": {
     Request: {
       message?: string;

--- a/src/generate-endpoints.ts
+++ b/src/generate-endpoints.ts
@@ -14,11 +14,12 @@ export const generateEndpointTypes = async ({
   Endpoints,
 }: OneSchemaDefinition) => {
   const masterSchema: JSONSchema4 = Object.entries(Endpoints).reduce(
-    (accum, [key, { Request, Response }]) => ({
+    (accum, [key, { Description, Request, Response }]) => ({
       ...accum,
       properties: {
         ...accum.properties,
         [key]: {
+          description: Description,
           type: 'object',
           additionalProperties: false,
           required: ['Request', 'PathParams', 'Response'],


### PR DESCRIPTION
A small enhancement: for the `schema.yaml` flow, this PR makes a change to pass a route's description into the rendered ts code for the `Endpoints` type. Since you refer to `one-schema` routes by their route, its especially useful to have the route description propagate down into the `Endpoints` type, e.g. so you can see a route's description on hover:

https://github.com/lifeomic/one-schema/assets/21148260/7d04e64c-9bab-4c49-8c50-c32409341812
