### PR TITLE
feat: support variadic middleware for routes

### DIFF
--- a/src/koa-utils.ts
+++ b/src/koa-utils.ts
@@ -94,6 +94,11 @@ export type EndpointImplementation<
   context: ContextOfEndpoint<RouteName, Request, RouterType>,
 ) => Response | Promise<Response>;
 
+export type OneSchemaRouterMiddleware<Context> = (
+  context: Context,
+  next: () => Promise<any>,
+) => any | Promise<any>;
+
 export const implementRoute = <
   Route extends string,
   Request,
@@ -103,6 +108,9 @@ export const implementRoute = <
   route: Route,
   router: R,
   parse: (ctx: ContextOfEndpoint<Route, Request, R>, data: unknown) => Request,
+  middlewares: OneSchemaRouterMiddleware<
+    ContextOfEndpoint<Route, Request, R>
+  >[],
   implementation: EndpointImplementation<Route, Request, Response, R>,
 ) => {
   // Separate method and path. e.g. 'POST my/route' => ['POST', 'my/route']
@@ -163,19 +171,19 @@ export const implementRoute = <
   // Register the route + handler on the router.
   switch (method) {
     case 'POST':
-      router.post(path, handler);
+      router.post(path, ...middlewares, handler);
       break;
     case 'GET':
-      router.get(path, handler);
+      router.get(path, ...middlewares, handler);
       break;
     case 'PUT':
-      router.put(path, handler);
+      router.put(path, ...middlewares, handler);
       break;
     case 'PATCH':
-      router.patch(path, handler);
+      router.patch(path, ...middlewares, handler);
       break;
     case 'DELETE':
-      router.delete(path, handler);
+      router.delete(path, ...middlewares, handler);
       break;
     default:
       throw new Error(`Unsupported method detected: ${route}`);

--- a/src/koa.ts
+++ b/src/koa.ts
@@ -135,6 +135,7 @@ export const implementSchema = <
           data,
         });
       },
+      [],
       routeHandler,
     );
   }


### PR DESCRIPTION
## Motivation
Many existing LifeOmic services use the "variadic middleware" style when declaring routes:

```typescript
router.get(
  '/something',
  middleware1,
  middleware2,
  middleware3,
  actualImplementation
);
```

Currently, it's very diffuclt to adopt `one-schema` in a service that uses this^ pattern, since it can't be represented in a `OneSchemaRouter` without significant refactoring.

That changes today! This PR introduces support for this syntax in a non-breaking way, thanks to TypeScript magic:

```typescript
router
  // This is the preferred path, supported today. Single implementation function. This is preferred + clearer!
  .implement(
    'POST /items',
    async (ctx) => {
      return item;
    }
  )

  // But now, this also works:
  .implement(
    'POST /items',
    async (ctx, next) => {
      await doSomethingElse();
      await next();
    },
    async (ctx) => {
      return item;
    }
  )

  // You can have many middlewares.
  .implement(
    'POST /items',
    middleware1,
    middleware2,
    middleware3,
    // The last function in the list _must_ return the required response.
    async (ctx) => {
      return item;
    }
  )
```

With this^ change, it will be much easier to adopt `one-schema` in existing services.