### PR TITLE
Introduce a simpler route declaration syntax, aimed at compatibility

### DIFF
--- a/src/compat-router.ts
+++ b/src/compat-router.ts
@@ -1,0 +1,89 @@
+import Router from '@koa/router';
+import { z } from 'zod';
+import {
+  ContextOfEndpoint,
+  EndpointImplementation,
+  OneSchemaRouterMiddleware,
+} from './koa-utils';
+import {
+  NamedClient,
+  OneSchemaRouter,
+  OneSchemaRouterConfig,
+  RouterEndpointDefinition,
+  ZodSchema,
+} from './router';
+import { AxiosInstance } from 'axios';
+
+type MethodMap = {
+  get: 'GET';
+  post: 'POST';
+  put: 'PUT';
+  patch: 'PATCH';
+  delete: 'DELETE';
+};
+
+export type OneSchemaCompatRouter<
+  Schema extends ZodSchema,
+  R extends Router,
+> = {
+  [Method in keyof MethodMap]: <
+    Path extends string,
+    Name extends string,
+    Endpoint extends RouterEndpointDefinition<Name>,
+  >(
+    path: Path,
+    meta: Endpoint,
+    ...middlewares: [
+      ...OneSchemaRouterMiddleware<
+        ContextOfEndpoint<
+          `${MethodMap[Method]} ${Path}`,
+          z.output<Endpoint['request']>,
+          R
+        >
+      >[],
+      EndpointImplementation<
+        `${MethodMap[Method]} ${Path}`,
+        z.output<Endpoint['request']>,
+        z.infer<Endpoint['response']>,
+        R
+      >,
+    ]
+  ) => OneSchemaCompatRouter<
+    Schema & {
+      [Route in `${MethodMap[Method]} ${Path}`]: Endpoint;
+    },
+    R
+  >;
+} & {
+  client: (instance: AxiosInstance) => NamedClient<Schema>;
+  middleware: () => Router.Middleware;
+};
+
+export const createCompatRouter = <R extends Router<any, any>>(
+  config: OneSchemaRouterConfig<R>,
+): OneSchemaCompatRouter<{}, R> => {
+  const _router = OneSchemaRouter.create(config);
+
+  const compatRouter: any = {
+    middleware: () => _router.middleware(),
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    client: (instance: any) => _router.client(instance),
+  };
+  for (const method of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+    compatRouter[method] = (
+      path: string,
+      endpoint: any,
+      ...middlewares: any[]
+    ) => {
+      const route = `${method.toUpperCase()} ${path}`;
+      _router
+        .declare({ ...endpoint, route })
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        .implement(route, ...middlewares);
+
+      return compatRouter;
+    };
+  }
+  return compatRouter;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './koa';
 export * from './types';
 export * from './router';
+export * from './compat-router';
 
 // We intentionally avoid exposing codegen-related modules here,
 // so that consumers don't unnecessarily bundle codegen logic

--- a/src/router.ts
+++ b/src/router.ts
@@ -24,7 +24,7 @@ export type RouterEndpointDefinition<Name> = {
 type Method = 'GET' | 'DELETE' | 'PUT' | 'POST' | 'PATCH';
 type RoughRoute = `${Method} ${string}`;
 
-type ZodSchema = {
+export type ZodSchema = {
   [route: string]: RouterEndpointDefinition<string>;
 };
 


### PR DESCRIPTION
## Motivation
This PR introduces a simplified syntax for declaring routes:

```typescript
const router = createCompatRouter({
  introspection: undefined,
  using: new Router(),
})
  .post(
    '/items',
    {
      name: 'createItem',
      request: z.object({ id: z.string() }),
      response: z.object({ id: z.string() }),
    },
    (ctx) => {
      // implementation
    },
  )
  .get(
    '/items/:id',
    {
      name: 'getItemById',
      request: z.object({ filter: z.string() }),
      response: z.object({ id: z.string() }),
    },
    (ctx) => {
      // implementation
    },
  );
```