### PR TITLE
Revert "feat: support variadic middleware for routes"

### DIFF
--- a/src/koa-utils.ts
+++ b/src/koa-utils.ts
@@ -94,11 +94,6 @@ export type EndpointImplementation<
   context: ContextOfEndpoint<RouteName, Request, RouterType>,
 ) => Response | Promise<Response>;
 
-export type OneSchemaRouterMiddleware<Context> = (
-  context: Context,
-  next: () => Promise<any>,
-) => any | Promise<any>;
-
 export const implementRoute = <
   Route extends string,
   Request,
@@ -108,9 +103,6 @@ export const implementRoute = <
   route: Route,
   router: R,
   parse: (ctx: ContextOfEndpoint<Route, Request, R>, data: unknown) => Request,
-  middlewares: OneSchemaRouterMiddleware<
-    ContextOfEndpoint<Route, Request, R>
-  >[],
   implementation: EndpointImplementation<Route, Request, Response, R>,
 ) => {
   // Separate method and path. e.g. 'POST my/route' => ['POST', 'my/route']
@@ -171,19 +163,19 @@ export const implementRoute = <
   // Register the route + handler on the router.
   switch (method) {
     case 'POST':
-      router.post(path, ...middlewares, handler);
+      router.post(path, handler);
       break;
     case 'GET':
-      router.get(path, ...middlewares, handler);
+      router.get(path, handler);
       break;
     case 'PUT':
-      router.put(path, ...middlewares, handler);
+      router.put(path, handler);
       break;
     case 'PATCH':
-      router.patch(path, ...middlewares, handler);
+      router.patch(path, handler);
       break;
     case 'DELETE':
-      router.delete(path, ...middlewares, handler);
+      router.delete(path, handler);
       break;
     default:
       throw new Error(`Unsupported method detected: ${route}`);

--- a/src/koa.ts
+++ b/src/koa.ts
@@ -135,7 +135,6 @@ export const implementSchema = <
           data,
         });
       },
-      [],
       routeHandler,
     );
   }

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -410,11 +410,10 @@ describe('output validation', () => {
             request: z.object({}),
             response: z.object({ message: z.string() }),
           })
-          .implement(
-            `${method} /items`,
+          .implement(`${method} /items`, () => ({
             // @ts-expect-error Intentionally writing incorrect TS here
-            () => ({ message: 123 }),
-          ),
+            message: 123,
+          })),
       );
 
       const { status } = await client.request({
@@ -507,105 +506,6 @@ describe('implementations', () => {
       expect(status).toStrictEqual(200);
       expect(data).toStrictEqual({ message: `${message}-response` });
     });
-  });
-});
-
-describe('using middleware', () => {
-  test('type errors are caught when using middleware', () => {
-    type CustomState = { message: string };
-
-    setup(() =>
-      OneSchemaRouter.create({
-        using: new Router<CustomState>(),
-        introspection: undefined,
-      })
-        .declare({
-          name: 'putItem',
-          route: 'PUT /items/:id',
-          request: z.object({ message: z.string() }),
-          response: z.object({ id: z.string(), message: z.string() }),
-        })
-        .implement(
-          'PUT /items/:id',
-          // @ts-expect-error
-          async (ctx, next) => {
-            ctx.state.message = ctx.request.body.message + '-response';
-            await next();
-          },
-          // We're leaving out the id value here, which should cause the TS error.
-          (ctx) => ({ message: ctx.state.message }),
-        )
-        .implement(
-          'PUT /items/:id',
-          async (ctx, next) => {
-            ctx.params.id;
-
-            ctx.request.body.message;
-
-            // @ts-expect-error The params should be well-typed.
-            ctx.params.bogus;
-
-            // @ts-expect-error The body should be well-typed.
-            ctx.request.body.bogus;
-
-            await next();
-          },
-          (ctx) => ({ id: 'test-id', message: ctx.state.message }),
-        )
-        .implement(
-          'PUT /items/:id',
-          (ctx, next) => {
-            // This call implicitly tests that `message` is a string.
-            ctx.state.message.endsWith('');
-
-            // @ts-expect-error The state should be well-typed.
-            ctx.state.bogus;
-
-            return next();
-          },
-          (ctx) => ({ id: 'test-id', message: ctx.state.message }),
-        ),
-    );
-  });
-
-  test('middlewares are actually executed', async () => {
-    const mock = jest.fn();
-    const { typed: client } = setup((router) =>
-      router
-        .declare({
-          name: 'putItem',
-          route: 'PUT /items/:id',
-          request: z.object({ message: z.string() }),
-          response: z.object({ id: z.string(), message: z.string() }),
-        })
-        .implement(
-          'PUT /items/:id',
-          async (ctx, next) => {
-            mock('middleware 1', ctx.state.message);
-            ctx.state.message = 'message 1';
-            await next();
-          },
-          (ctx, next) => {
-            mock('middleware 2', ctx.state.message);
-            ctx.state.message = 'message 2';
-            return next();
-          },
-          (ctx) => ({ id: ctx.params.id, message: ctx.state.message }),
-        ),
-    );
-
-    const { status, data } = await client.putItem({
-      id: 'test-id-bleh',
-      message: 'test-message',
-    });
-
-    expect(status).toStrictEqual(200);
-    expect(data).toStrictEqual({ id: 'test-id-bleh', message: 'message 2' });
-
-    expect(mock.mock.calls).toEqual([
-      ['middleware 1', undefined],
-      ['middleware 2', 'message 1'],
-    ]);
   });
 });
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,10 +4,8 @@ import { fromZodError } from 'zod-validation-error';
 import zodToJsonSchema from 'zod-to-json-schema';
 import compose = require('koa-compose');
 import {
-  ContextOfEndpoint,
   EndpointImplementation,
   implementRoute,
-  OneSchemaRouterMiddleware,
   PathParamsOf,
 } from './koa-utils';
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -99,23 +97,14 @@ export class OneSchemaRouter<
 
   implement<Route extends keyof Schema & string>(
     route: Route,
-    ...middlewares: [
-      ...OneSchemaRouterMiddleware<
-        ContextOfEndpoint<Route, z.output<Schema[Route]['request']>, R>
-      >[],
-      EndpointImplementation<
-        Route,
-        z.output<Schema[Route]['request']>,
-        z.infer<Schema[Route]['response']>,
-        R
-      >,
-    ]
-  ): this {
+    implementation: EndpointImplementation<
+      Route,
+      z.output<Schema[Route]['request']>,
+      z.infer<Schema[Route]['response']>,
+      R
+    >,
+  ) {
     const endpoint = this.schema[route];
-
-    const mws = middlewares.slice(0, -1) as any[];
-
-    const implementation = middlewares.at(-1) as any;
 
     implementRoute(
       route,
@@ -130,8 +119,6 @@ export class OneSchemaRouter<
         }
         return res.data;
       },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      mws,
       async (ctx) => {
         const result = await implementation(ctx);
         const res = endpoint.response.safeParse(result);


### PR DESCRIPTION
This PR rolls back the changes from #85.

## Motivation
We discovered that #85 significantly degraded the behavior of auto-complete in route implementations. This is super lame and antithetical to the value of `one-schema`. Since there has been minimal/no adoption of this new feature, going to roll it back as a `fix:` for now, until we can find a way to release it without degrading auto-complete.