### PR TITLE
fix: make prettier a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "js-yaml": "^4.1.0",
     "json-schema-to-typescript": "^10.1.5",
     "openapi-types": "^12.1.3",
+    "prettier": "^2.6.2",
     "yargs": "^17.5.1",
     "zod-to-json-schema": "^3.20.2",
     "zod-validation-error": "^0.3.0"
@@ -48,7 +49,6 @@
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
     "openapi-schema-validator": "^12.1.3",
-    "prettier": "^2.6.2",
     "semantic-release": "^19.0.3",
     "tmp": "^0.2.1",
     "ts-jest": "^28.0.3",


### PR DESCRIPTION
## Motivation
Prettier is used in the CLI here: https://github.com/lifeomic/one-schema/blob/master/src/bin/cli.ts#L34

By not making this a production dependency, we force consumers to have `prettier` installed, and we use their version instead. This creates a bug for any consumers using `prettier` v3, which returns a `Promise` from `format`, instead of a synchronous `string`.