### PR TITLE
feat: generate just typescript

### DIFF
--- a/src/__snapshots__/router.test.ts.snap
+++ b/src/__snapshots__/router.test.ts.snap
@@ -29,8 +29,38 @@ export type Endpoints = {
   };
 };
 
-export declare class Client {
-  constructor(client: AxiosInstance);
+/* eslint-disable */
+
+const substituteParams = (url: string, params: Object) =>
+  Object.entries(params).reduce(
+    (url, [name, value]) => url.replace(\\":\\" + name, encodeURIComponent(value)),
+    url
+  );
+
+const removePathParams = (url: string, params: Object) =>
+  Object.entries(params)
+    .filter(([key, value]) => value !== undefined)
+    .reduce(
+      (accum, [name, value]) =>
+        url.includes(\\":\\" + name) ? accum : { ...accum, [name]: value },
+      {}
+    );
+
+const parseQueryParamsFromPagingLink = (link: string) => {
+  const params = new URLSearchParams(link.split(\\"?\\")[1]);
+
+  return {
+    nextPageToken: params.get(\\"nextPageToken\\"),
+    pageSize: params.get(\\"pageSize\\"),
+  };
+};
+
+export class Client {
+  client: AxiosInstance;
+
+  constructor(client: AxiosInstance) {
+    this.client = client;
+  }
 
   /**
    * Executes the \`POST /items\` endpoint.
@@ -44,7 +74,14 @@ export declare class Client {
     data: Endpoints[\\"POST /items\\"][\\"Request\\"] &
       Endpoints[\\"POST /items\\"][\\"PathParams\\"],
     config?: AxiosRequestConfig
-  ): Promise<AxiosResponse<Endpoints[\\"POST /items\\"][\\"Response\\"]>>;
+  ): Promise<AxiosResponse<Endpoints[\\"POST /items\\"][\\"Response\\"]>> {
+    return this.client.request({
+      ...config,
+      method: \\"POST\\",
+      data: removePathParams(\\"/items\\", data),
+      url: substituteParams(\\"/items\\", data),
+    });
+  }
 
   /**
    * Executes the \`GET /items/:id\` endpoint.
@@ -58,14 +95,21 @@ export declare class Client {
     data: Endpoints[\\"GET /items/:id\\"][\\"Request\\"] &
       Endpoints[\\"GET /items/:id\\"][\\"PathParams\\"],
     config?: AxiosRequestConfig
-  ): Promise<AxiosResponse<Endpoints[\\"GET /items/:id\\"][\\"Response\\"]>>;
+  ): Promise<AxiosResponse<Endpoints[\\"GET /items/:id\\"][\\"Response\\"]>> {
+    return this.client.request({
+      ...config,
+      method: \\"GET\\",
+      params: removePathParams(\\"/items/:id\\", data),
+      url: substituteParams(\\"/items/:id\\", data),
+    });
+  }
 
   /**
    * Paginates exhaustively through the provided \`request\`, using the specified
    * \`data\`. A \`pageSize\` can be specified in the \`data\` to customize the
    * page size for pagination.
    */
-  paginate<T extends { nextPageToken?: string; pageSize?: string }, Item>(
+  async paginate<T extends { nextPageToken?: string; pageSize?: string }, Item>(
     request: (
       data: T,
       config?: AxiosRequestConfig
@@ -74,7 +118,29 @@ export declare class Client {
     >,
     data: T,
     config?: AxiosRequestConfig
-  ): Promise<Item[]>;
+  ): Promise<Item[]> {
+    const result = [];
+
+    let nextPageParams = {};
+    do {
+      // @ts-expect-error
+      const response = await this[request.name](
+        { ...nextPageParams, ...data },
+        config
+      );
+
+      result.push(...response.data.items);
+
+      nextPageParams = response.data.links.next
+        ? parseQueryParamsFromPagingLink(response.data.links.next)
+        : {};
+      // @ts-expect-error
+    } while (!!nextPageParams.nextPageToken);
+
+    return result;
+  }
 }
+
+module.exports.Client = Client;
 "
 `;

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -125,16 +125,9 @@ const program = yargs(process.argv.slice(2))
         outputClass: argv.name,
       });
 
-      writeGeneratedFile(argv.output.replace('.ts', '.js'), output.javascript, {
+      writeGeneratedFile(argv.output, output.typescript, {
         format: argv.format,
       });
-      writeGeneratedFile(
-        argv.output.replace('.ts', '.d.ts'),
-        output.declaration,
-        {
-          format: argv.format,
-        },
-      );
     },
   )
   .command(

--- a/src/integration.axios.test.ts
+++ b/src/integration.axios.test.ts
@@ -13,8 +13,7 @@ const testGeneratedFile = (ext: string) => `${__dirname}/test-generated${ext}`;
 
 const generateAndFormat = (input: GenerateAxiosClientInput) =>
   generateAxiosClient(input).then((source) => ({
-    javascript: format(source.javascript, { parser: 'babel' }),
-    declaration: format(source.declaration, { parser: 'typescript' }),
+    typescript: format(source.typescript, { parser: 'typescript' }),
   }));
 
 const mockMiddleware = jest.fn();
@@ -122,10 +121,9 @@ beforeEach(async () => {
 
   const output = await generateAndFormat({ spec, outputClass: 'Service' });
 
-  writeFileSync(testGeneratedFile('.js'), output.javascript);
-  writeFileSync(testGeneratedFile('.d.ts'), output.declaration);
+  writeFileSync(testGeneratedFile('.ts'), output.typescript);
 
-  const { Service } = await import(testGeneratedFile('.js'));
+  const { Service } = await import(testGeneratedFile('.ts'));
   client = new Service(context.client);
 });
 

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -564,7 +564,7 @@ describe('introspection', () => {
       outputClass: 'Client',
     });
 
-    const formattedDeclaration = format(clientCode.declaration, {
+    const formattedDeclaration = format(clientCode.typescript, {
       parser: 'typescript',
     });
 


### PR DESCRIPTION
_INCLUDES BREAKING CHANGE_

# Motivations

In order to make integration in downstream consumers easier, we've migrated from generating separate code (`.js`) and declaration (`.d.ts`) files to only generating a single TypeScript (`.ts`) file. The main reason for this is that `tsc` does not include `.d.ts` files by default in its build process, which break consumers that have used this package before the build step, since they'll lose the generated `.d.ts` file when their build process generates its own from the `.js` file that this package also generates.